### PR TITLE
fix(codebases): prepare finding ledger for health v3 (AIO-1171)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1806,3 +1806,20 @@ npm run check:docs   # run locally before pushing
 
 When you add/remove a route, table, or source: update the matching block here in the same
 PR. The guard verifies structure only — keep the diagrams and prose accurate by review.
+
+### Health v3 ledger compatibility (AIO-1171)
+
+The existing `reconcile_codebase_findings` RPC admits persisted health v2/v3 and
+orders newest evidence across both versions. Migration
+`20260910060000_codebase_finding_health_v3.sql` and the bootstrap schema contain
+the same function. Exact team/codebase/head/JSONB identity and the transaction-scoped
+advisory lock remain unchanged; lifecycle history stays in the existing ledger.
+This database prerequisite does not enable the public v3 boundary or TypeScript
+wrapper: AIO-1096 owns that consumer activation, and AIO-1097 owns emission.
+
+Metrics upsert and ledger reconciliation remain separate transactions; a concurrent
+same-head replacement can make the superseded RPC fail its identity check. This
+change neither weakens that check nor claims whole-ingest transaction atomicity.
+Before activation an old-function rollback preserves v2 operation. After activation,
+retain this compatible RPC or disable v3 emission before a reviewed rollback; never
+delete stored evidence or manually load production schema from a worktree.

--- a/postgres/migrations/20260910060000_codebase_finding_health_v3.sql
+++ b/postgres/migrations/20260910060000_codebase_finding_health_v3.sql
@@ -1,0 +1,268 @@
+-- AIO-1171: prepare the existing ledger for health v3 before public activation.
+-- Same signature, snapshot identity, lock and lifecycle; v2 remains compatible.
+create or replace function reconcile_codebase_findings(
+  p_team_id uuid,
+  p_codebase_id uuid,
+  p_metrics_id uuid,
+  p_health jsonb
+) returns jsonb
+language plpgsql
+as $$
+declare
+  v_schema_version text := coalesce(p_health->>'schema_version', '');
+  v_evidence_status text;
+  v_head_sha text;
+  v_observed_at timestamptz;
+  v_latest_observed_at timestamptz;
+  v_snapshot_is_stale boolean := false;
+  v_finding jsonb;
+  v_row codebase_findings%rowtype;
+  v_previous_status text;
+  v_event_type text;
+  v_new_status text;
+  v_detected integer := 0;
+  v_observed integer := 0;
+  v_resolved integer := 0;
+  v_reopened integer := 0;
+  v_stale integer := 0;
+begin
+  if v_schema_version not in ('2', '3') then
+    return jsonb_build_object(
+      'detected', 0, 'observed', 0, 'resolved', 0, 'reopened', 0, 'stale', 0
+    );
+  end if;
+
+  v_evidence_status := p_health->>'evidence_status';
+  v_head_sha := p_health->>'head_sha';
+  v_observed_at := (p_health->>'measured_at')::timestamptz;
+
+  if not exists (
+    select 1
+    from code_metrics
+    where id = p_metrics_id
+      and team_id = p_team_id
+      and codebase_id = p_codebase_id
+      and head_sha = v_head_sha
+      and codebase_health = p_health
+  ) then
+    raise exception 'finding reconciliation metrics identity mismatch';
+  end if;
+
+  -- Serialize lifecycle projection per codebase. Metrics writes happen before this
+  -- function, so whichever reconciliation wins the lock can see every committed v2/v3
+  -- measurement and classify an out-of-order snapshot deterministically.
+  perform pg_advisory_xact_lock(
+    hashtextextended(p_team_id::text || ':' || p_codebase_id::text, 0)
+  );
+  select coalesce(
+    max((codebase_health->>'measured_at')::timestamptz),
+    v_observed_at
+  )
+  into v_latest_observed_at
+  from code_metrics
+  where team_id = p_team_id
+    and codebase_id = p_codebase_id
+    and codebase_health->>'schema_version' in ('2', '3');
+  v_snapshot_is_stale := v_observed_at < v_latest_observed_at;
+
+  for v_finding in
+    select value from jsonb_array_elements(coalesce(p_health->'findings', '[]'::jsonb))
+  loop
+    select *
+    into v_row
+    from codebase_findings
+    where team_id = p_team_id
+      and codebase_id = p_codebase_id
+      and fingerprint = v_finding->>'fingerprint'
+    for update;
+
+    if not found then
+      v_new_status := case when v_snapshot_is_stale then 'stale_analysis' else 'open' end;
+      v_event_type := case when v_snapshot_is_stale then 'stale_analysis' else 'detected' end;
+      insert into codebase_findings (
+        team_id, codebase_id, fingerprint, status, check_id, axis, kind, severity,
+        evidence_status, remediation_tier, first_seen_sha, last_seen_sha,
+        first_seen_at, last_seen_at, latest_metrics_id
+      ) values (
+        p_team_id,
+        p_codebase_id,
+        v_finding->>'fingerprint',
+        v_new_status,
+        v_finding->>'check_id',
+        v_finding->>'axis',
+        v_finding->>'kind',
+        v_finding->>'severity',
+        v_finding->>'evidence_status',
+        (v_finding->>'remediation_tier')::integer,
+        v_head_sha,
+        v_head_sha,
+        v_observed_at,
+        v_observed_at,
+        p_metrics_id
+      )
+      on conflict (team_id, codebase_id, fingerprint) do nothing
+      returning * into v_row;
+
+      if found then
+        insert into codebase_finding_events (
+          team_id, codebase_id, finding_id, metrics_id, event_type,
+          from_status, to_status, head_sha, observed_at, details
+        ) values (
+          p_team_id, p_codebase_id, v_row.id, p_metrics_id, v_event_type,
+          null, v_new_status, v_head_sha, v_observed_at,
+          jsonb_build_object(
+            'rubric_version', p_health->>'rubric_version',
+            'profile_id', p_health->>'profile_id',
+            'profile_version', p_health->>'profile_version',
+            'evidence_status', v_evidence_status
+          )
+        )
+        on conflict (finding_id, metrics_id, event_type) do nothing;
+        if v_snapshot_is_stale then
+          v_stale := v_stale + 1;
+        else
+          v_detected := v_detected + 1;
+        end if;
+        continue;
+      end if;
+
+      select *
+      into v_row
+      from codebase_findings
+      where team_id = p_team_id
+        and codebase_id = p_codebase_id
+        and fingerprint = v_finding->>'fingerprint'
+      for update;
+    end if;
+
+    if exists (
+      select 1 from codebase_finding_events
+      where finding_id = v_row.id and metrics_id = p_metrics_id
+    ) then
+      continue;
+    end if;
+
+    if v_snapshot_is_stale or v_observed_at < greatest(
+      v_row.last_seen_at,
+      coalesce(v_row.resolved_at, '-infinity'::timestamptz)
+    ) then
+      insert into codebase_finding_events (
+        team_id, codebase_id, finding_id, metrics_id, event_type,
+        from_status, to_status, head_sha, observed_at, details
+      ) values (
+        p_team_id, p_codebase_id, v_row.id, p_metrics_id, 'stale_analysis',
+        v_row.status, v_row.status, v_head_sha, v_observed_at,
+        jsonb_build_object(
+          'rubric_version', p_health->>'rubric_version',
+          'profile_id', p_health->>'profile_id',
+          'profile_version', p_health->>'profile_version',
+          'evidence_status', v_evidence_status
+        )
+      )
+      on conflict (finding_id, metrics_id, event_type) do nothing;
+      v_stale := v_stale + 1;
+      continue;
+    end if;
+
+    v_previous_status := v_row.status;
+    if v_previous_status in ('resolved', 'stale_analysis') then
+      v_event_type := 'reopened';
+      v_row.status := 'reopened';
+      v_reopened := v_reopened + 1;
+    else
+      v_event_type := 'observed';
+      v_observed := v_observed + 1;
+    end if;
+
+    update codebase_findings
+    set status = v_row.status,
+        check_id = v_finding->>'check_id',
+        axis = v_finding->>'axis',
+        kind = v_finding->>'kind',
+        severity = v_finding->>'severity',
+        evidence_status = v_finding->>'evidence_status',
+        remediation_tier = (v_finding->>'remediation_tier')::integer,
+        occurrence_count = occurrence_count + 1,
+        last_seen_sha = v_head_sha,
+        last_seen_at = v_observed_at,
+        resolved_at = case when v_row.status = 'reopened' then null else resolved_at end,
+        latest_metrics_id = p_metrics_id,
+        updated_at = now()
+    where id = v_row.id and team_id = p_team_id;
+
+    insert into codebase_finding_events (
+      team_id, codebase_id, finding_id, metrics_id, event_type,
+      from_status, to_status, head_sha, observed_at, details
+    ) values (
+      p_team_id, p_codebase_id, v_row.id, p_metrics_id, v_event_type,
+      v_previous_status, v_row.status, v_head_sha, v_observed_at,
+      jsonb_build_object(
+        'rubric_version', p_health->>'rubric_version',
+        'profile_id', p_health->>'profile_id',
+        'profile_version', p_health->>'profile_version',
+        'evidence_status', v_evidence_status
+      )
+    )
+    on conflict (finding_id, metrics_id, event_type) do nothing;
+  end loop;
+
+  if v_evidence_status = 'complete' and not v_snapshot_is_stale then
+    for v_row in
+      select *
+      from codebase_findings f
+      where f.team_id = p_team_id
+        and f.codebase_id = p_codebase_id
+        and (
+          f.status in ('open', 'reopened')
+          or (
+            f.status in ('accepted', 'risk_accepted', 'false_positive')
+            and f.decision_at <= v_observed_at
+          )
+        )
+        and f.last_seen_at <= v_observed_at
+        and not exists (
+          select 1
+          from jsonb_array_elements(coalesce(p_health->'findings', '[]'::jsonb)) current_finding
+          where current_finding->>'fingerprint' = f.fingerprint
+        )
+      for update
+    loop
+      update codebase_findings
+      set status = 'resolved',
+          resolved_at = v_observed_at,
+          decision_reason = null,
+          decision_owner_member_id = null,
+          decision_by_member_id = null,
+          decision_at = null,
+          decision_expires_at = null,
+          latest_metrics_id = p_metrics_id,
+          updated_at = now()
+      where id = v_row.id and team_id = p_team_id;
+
+      insert into codebase_finding_events (
+        team_id, codebase_id, finding_id, metrics_id, event_type,
+        from_status, to_status, head_sha, observed_at, details
+      ) values (
+        p_team_id, p_codebase_id, v_row.id, p_metrics_id, 'resolved',
+        v_row.status, 'resolved', v_head_sha, v_observed_at,
+        jsonb_build_object(
+          'rubric_version', p_health->>'rubric_version',
+          'profile_id', p_health->>'profile_id',
+          'profile_version', p_health->>'profile_version',
+          'evidence_status', v_evidence_status
+        )
+      )
+      on conflict (finding_id, metrics_id, event_type) do nothing;
+      v_resolved := v_resolved + 1;
+    end loop;
+  end if;
+
+  return jsonb_build_object(
+    'detected', v_detected,
+    'observed', v_observed,
+    'resolved', v_resolved,
+    'reopened', v_reopened,
+    'stale', v_stale
+  );
+end;
+$$;

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1866,7 +1866,7 @@ declare
   v_reopened integer := 0;
   v_stale integer := 0;
 begin
-  if v_schema_version <> '2' then
+  if v_schema_version not in ('2', '3') then
     return jsonb_build_object(
       'detected', 0, 'observed', 0, 'resolved', 0, 'reopened', 0, 'stale', 0
     );
@@ -1889,7 +1889,7 @@ begin
   end if;
 
   -- Serialize lifecycle projection per codebase. Metrics writes happen before this
-  -- function, so whichever reconciliation wins the lock can see every committed v2
+  -- function, so whichever reconciliation wins the lock can see every committed v2/v3
   -- measurement and classify an out-of-order snapshot deterministically.
   perform pg_advisory_xact_lock(
     hashtextextended(p_team_id::text || ':' || p_codebase_id::text, 0)
@@ -1902,7 +1902,7 @@ begin
   from code_metrics
   where team_id = p_team_id
     and codebase_id = p_codebase_id
-    and codebase_health->>'schema_version' = '2';
+    and codebase_health->>'schema_version' in ('2', '3');
   v_snapshot_is_stale := v_observed_at < v_latest_observed_at;
 
   for v_finding in

--- a/test/datamechanics/codebase-health-v3-rpc.datamechanics.test.ts
+++ b/test/datamechanics/codebase-health-v3-rpc.datamechanics.test.ts
@@ -1,0 +1,309 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "pg";
+import { readFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { db, seedTeam } from "./helpers";
+
+// AIO-1171: SQL compatibility precedes public v3 acceptance (AIO-1096). Test-only
+// persisted canonical fixtures exercise the existing RPC, never a second writer.
+const fixtureBytes = readFileSync(
+  "test/fixtures/contract/codebase-payload-1.25-fixtures.json",
+);
+const fixtures = JSON.parse(fixtureBytes.toString());
+const canonical = fixtures.valid.find(
+  (f: { name: string }) => f.name === "valid-v3-complete",
+).payload.metrics.codebase_health;
+const finding = {
+  fingerprint: "a".repeat(64),
+  check_id: "test_rigor",
+  axis: "structure",
+  kind: "quality_issue",
+  severity: "high",
+  evidence_status: "complete",
+  remediation_tier: 0,
+};
+const client = new Client({ connectionString: process.env.DATABASE_TEST_URL });
+beforeAll(() => client.connect());
+afterAll(() => client.end());
+
+function health(
+  version: "2" | "3",
+  hour: number,
+  present = true,
+  complete = true,
+) {
+  const value = structuredClone(canonical);
+  value.schema_version = version;
+  if (version === "2") delete value.check_coverage;
+  value.head_sha = hour.toString(16).padStart(40, "0");
+  value.measured_at = `2026-09-01T${String(hour).padStart(2, "0")}:00:00Z`;
+  value.findings = present ? [finding] : [];
+  if (!complete) {
+    value.evidence_status = "partial";
+    value.quality_gate = "unknown";
+    value.automation_eligible = false;
+  }
+  return value;
+}
+async function repository(teamId: string) {
+  const { rows } = await client.query(
+    "insert into codebases(team_id,slug) values($1,$2) returning id",
+    [teamId, randomUUID()],
+  );
+  return rows[0].id as string;
+}
+async function persist(
+  teamId: string,
+  codebaseId: string,
+  value: ReturnType<typeof health>,
+) {
+  const { rows } = await client.query(
+    "insert into code_metrics(team_id,codebase_id,head_sha,codebase_health) values($1,$2,$3,$4) returning id",
+    [teamId, codebaseId, value.head_sha, JSON.stringify(value)],
+  );
+  return rows[0].id as string;
+}
+function reconcile(
+  teamId: string,
+  codebaseId: string,
+  metricsId: string,
+  value: ReturnType<typeof health>,
+) {
+  return db().rpc("reconcile_codebase_findings", {
+    p_team_id: teamId,
+    p_codebase_id: codebaseId,
+    p_metrics_id: metricsId,
+    p_health: value,
+  });
+}
+async function snapshot() {
+  const findings = await client.query(
+    "select * from codebase_findings order by id",
+  );
+  const events = await client.query(
+    "select * from codebase_finding_events order by id",
+  );
+  return { findings: findings.rows, events: events.rows };
+}
+
+describe("health v3 SQL compatibility", () => {
+  it("uses exact canonical 1.25 fixture bytes", () => {
+    expect(createHash("sha256").update(fixtureBytes).digest("hex")).toBe(
+      "22bc99241032d38578be67a3130af08404efe4588cf678046fb687a00ab91d5a",
+    );
+    expect(canonical.schema_version).toBe("3");
+  });
+
+  it.each(["2", "3"] as const)(
+    "v%s detects, reobserves, resolves and reopens with replay idempotence",
+    async (version) => {
+      const seed = await seedTeam();
+      const repo = await repository(seed.teamId);
+      const first = health(version, 1);
+      const firstId = await persist(seed.teamId, repo, first);
+      expect(await reconcile(seed.teamId, repo, firstId, first)).toMatchObject({
+        error: null,
+        data: { detected: 1 },
+      });
+      const beforeReplay = await snapshot();
+      expect(beforeReplay.findings).toHaveLength(1);
+      expect(beforeReplay.events.map((e) => e.event_type)).toEqual([
+        "detected",
+      ]);
+      expect(
+        (await reconcile(seed.teamId, repo, firstId, first)).error,
+      ).toBeNull();
+      expect(await snapshot()).toEqual(beforeReplay);
+
+      for (const [hour, present, complete, expected] of [
+        [2, true, true, "observed"],
+        [3, false, false, null],
+        [4, false, true, "resolved"],
+        [5, true, true, "reopened"],
+      ] as const) {
+        const value = health(version, hour, present, complete);
+        const id = await persist(seed.teamId, repo, value);
+        const before = await snapshot();
+        const result = await reconcile(seed.teamId, repo, id, value);
+        expect(result.error).toBeNull();
+        const after = await snapshot();
+        if (expected)
+          expect(
+            after.events.filter((e) => e.event_type === expected),
+          ).toHaveLength(1);
+        else expect(after).toEqual(before);
+        expect(
+          (await reconcile(seed.teamId, repo, id, value)).error,
+        ).toBeNull();
+        expect(await snapshot()).toEqual(after);
+        expect(
+          (
+            await client.query(
+              "select codebase_health from code_metrics where id=$1",
+              [id],
+            )
+          ).rows[0].codebase_health,
+        ).toEqual(value);
+      }
+      const final = await snapshot();
+      expect(final.findings).toHaveLength(1);
+      expect(final.findings[0]).toMatchObject({
+        status: "reopened",
+        occurrence_count: 3,
+      });
+      expect(final.events).toHaveLength(4);
+    },
+  );
+
+  it.each([
+    ["2", "3"],
+    ["3", "2"],
+    ["3", "3"],
+  ] as const)(
+    "older v%s cannot become active after a newer v%s clean scan",
+    async (olderVersion, newerVersion) => {
+      const seed = await seedTeam();
+      const repo = await repository(seed.teamId);
+      const newer = health(newerVersion, 5, false);
+      const newerId = await persist(seed.teamId, repo, newer);
+      expect(
+        (await reconcile(seed.teamId, repo, newerId, newer)).error,
+      ).toBeNull();
+      const older = health(olderVersion, 2);
+      const olderId = await persist(seed.teamId, repo, older);
+      expect(await reconcile(seed.teamId, repo, olderId, older)).toMatchObject({
+        error: null,
+        data: { stale: 1, detected: 0 },
+      });
+      const state = await snapshot();
+      expect(state.findings).toHaveLength(1);
+      expect(state.findings[0].status).toBe("stale_analysis");
+      expect(state.events.map((e) => e.event_type)).toEqual(["stale_analysis"]);
+      const newest = health(newerVersion, 6);
+      const newestId = await persist(seed.teamId, repo, newest);
+      expect(
+        await reconcile(seed.teamId, repo, newestId, newest),
+      ).toMatchObject({ error: null, data: { reopened: 1 } });
+      expect((await snapshot()).findings[0].status).toBe("reopened");
+    },
+  );
+
+  it("rejects wrong team, codebase, head and changed-object identity without writes", async () => {
+    const seed = await seedTeam();
+    const other = await seedTeam();
+    const repo = await repository(seed.teamId);
+    const otherRepo = await repository(other.teamId);
+    const value = health("3", 1);
+    const id = await persist(seed.teamId, repo, value);
+    expect((await reconcile(seed.teamId, repo, id, value)).error).toBeNull();
+    const baseline = await snapshot();
+    for (const [team, codebase, candidate] of [
+      [other.teamId, repo, value],
+      [seed.teamId, otherRepo, value],
+      [seed.teamId, repo, { ...value, head_sha: "f".repeat(40) }],
+      [seed.teamId, repo, { ...value, score_pct: 1 }],
+    ] as const) {
+      expect(
+        (await reconcile(team, codebase, id, candidate)).error?.message,
+      ).toContain("metrics identity mismatch");
+      expect(await snapshot()).toEqual(baseline);
+    }
+  });
+
+  it("keeps legacy v1 metrics-only", async () => {
+    const seed = await seedTeam();
+    const repo = await repository(seed.teamId);
+    const value = { ...health("3", 1), schema_version: "1" };
+    const id = await persist(seed.teamId, repo, value);
+    expect(await reconcile(seed.teamId, repo, id, value)).toMatchObject({
+      error: null,
+      data: { detected: 0 },
+    });
+    expect(await snapshot()).toEqual({ findings: [], events: [] });
+  });
+});
+
+function functionDefinition(source: string) {
+  const start = source.indexOf(
+    "create or replace function reconcile_codebase_findings(",
+  );
+  const end = source.indexOf("\n$$;", start);
+  if (start < 0 || end < 0) throw new Error("ledger function missing");
+  return source.slice(start, end + 4);
+}
+
+it("upgrades the baseline in place, matches bootstrap, and rolls back/reapplies safely", async () => {
+  const baseline = functionDefinition(
+    readFileSync(
+      "postgres/migrations/20260804120000_codebase_finding_ledger.sql",
+      "utf8",
+    ),
+  );
+  const migration = readFileSync(
+    "postgres/migrations/20260910060000_codebase_finding_health_v3.sql",
+    "utf8",
+  );
+  const bootstrap = functionDefinition(
+    readFileSync("postgres/schema.sql", "utf8"),
+  );
+  const catalog = async () =>
+    (
+      await client.query(`select p.oid, p.proacl, p.proowner,
+    pg_get_functiondef(p.oid) as definition,
+    (select jsonb_agg(to_jsonb(d) order by d.classid,d.objid,d.objsubid,d.refclassid,d.refobjid,d.refobjsubid,d.deptype)
+      from pg_depend d where d.objid=p.oid or d.refobjid=p.oid) as dependencies
+    from pg_proc p where p.oid='reconcile_codebase_findings(uuid,uuid,uuid,jsonb)'::regprocedure`)
+    ).rows[0];
+  try {
+    await client.query(baseline);
+    const before = await catalog();
+    const seed = await seedTeam();
+    const repo = await repository(seed.teamId);
+    const value = health("3", 1);
+    const id = await persist(seed.teamId, repo, value);
+    expect(await reconcile(seed.teamId, repo, id, value)).toMatchObject({
+      error: null,
+      data: { detected: 0 },
+    });
+    expect((await snapshot()).findings).toHaveLength(0);
+
+    await client.query(migration);
+    const upgraded = await catalog();
+    expect(upgraded.oid).toBe(before.oid);
+    expect(upgraded.proacl).toEqual(before.proacl);
+    expect(upgraded.proowner).toBe(before.proowner);
+    expect(upgraded.dependencies).toEqual(before.dependencies);
+    expect(await reconcile(seed.teamId, repo, id, value)).toMatchObject({
+      error: null,
+      data: { detected: 1 },
+    });
+    const retained = await snapshot();
+    await client.query(bootstrap);
+    expect(await catalog()).toEqual(upgraded);
+
+    await client.query(baseline);
+    expect(await catalog()).toEqual(before);
+    expect(await snapshot()).toEqual(retained);
+    const v2 = health("2", 2);
+    const v2Id = await persist(seed.teamId, repo, v2);
+    expect(await reconcile(seed.teamId, repo, v2Id, v2)).toMatchObject({
+      error: null,
+      data: { observed: 1 },
+    });
+    await client.query(migration);
+    expect(await catalog()).toEqual(upgraded);
+    const v3 = health("3", 3, false);
+    const v3Id = await persist(seed.teamId, repo, v3);
+    expect(await reconcile(seed.teamId, repo, v3Id, v3)).toMatchObject({
+      error: null,
+      data: { resolved: 1 },
+    });
+    expect((await snapshot()).events).toHaveLength(3);
+    console.info("AIO-1171 function SHA256", {
+      baseline: createHash("sha256").update(before.definition).digest("hex"),
+      upgraded: createHash("sha256").update(upgraded.definition).digest("hex"),
+    });
+  } finally {
+    await client.query(migration);
+  }
+});

--- a/test/datamechanics/codebase-health-v3-rpc.datamechanics.test.ts
+++ b/test/datamechanics/codebase-health-v3-rpc.datamechanics.test.ts
@@ -23,8 +23,24 @@ const finding = {
   remediation_tier: 0,
 };
 const client = new Client({ connectionString: process.env.DATABASE_TEST_URL });
-beforeAll(() => client.connect());
-afterAll(() => client.end());
+beforeAll(async () => {
+  await client.connect();
+  await client.query(
+    readFileSync(
+      "postgres/migrations/20260910060000_codebase_finding_health_v3.sql",
+      "utf8",
+    ),
+  );
+});
+afterAll(async () => {
+  try {
+    await client.query(
+      functionDefinition(readFileSync("postgres/schema.sql", "utf8")),
+    );
+  } finally {
+    await client.end();
+  }
+});
 
 function health(
   version: "2" | "3",

--- a/test/datamechanics/codebase-health-v3-rpc.datamechanics.test.ts
+++ b/test/datamechanics/codebase-health-v3-rpc.datamechanics.test.ts
@@ -251,7 +251,7 @@ function functionDefinition(source: string) {
 it("upgrades the baseline in place, matches bootstrap, and rolls back/reapplies safely", async () => {
   const baseline = functionDefinition(
     readFileSync(
-      "postgres/migrations/20260804120000_codebase_finding_ledger.sql",
+      "postgres/migrations/20260804160000_explainable_debt_decisions.sql",
       "utf8",
     ),
   );

--- a/test/fixtures/contract/codebase-payload-1.25-fixtures.json
+++ b/test/fixtures/contract/codebase-payload-1.25-fixtures.json
@@ -1,0 +1,15099 @@
+{
+  "$schema": "./codebase-payload-1.25.schema.json",
+  "version": "1.25",
+  "_note": "Canonical parity fixtures for codebase-payload-1.24.schema.json (POST /api/v1/codebases). Synthetic data only. valid/invalid pin JSON Schema parity. brain_invalid pins the sibling-count invariants that JSON Schema 2020-12 cannot express and the Brain must reject at its boundary. 1.23 added optional versioned commit classification and first-parent fix-analysis counts; 1.24 adds scanner identity - a payload that declares its build, one that declares a version but no SHA, one that declares neither, and - load-bearing - one whose version string the brain cannot parse, which must still be ACCEPTED. Staleness is a reading of the payload, never a reason to refuse it: a 422 drops the repo's entire scan and returns before the ingest run is logged, so an unreadable version must degrade to 'unknown scanner', not to 'no data at all'. Neither revision changes legacy payload validity. 1.25 adds closed v3 check coverage; coverage_invalid fixtures are schema-valid but MUST fail whole-request semantic validation. Legacy vectors are preserved.",
+  "valid": [
+    {
+      "name": "valid-with-health: full metrics block plus codebase_health",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          }
+        }
+      }
+    },
+    {
+      "name": "valid-without-health: pre-1.15 payload remains valid unchanged",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            }
+          },
+          "readiness_rubric_version": "1.0.0"
+        }
+      }
+    },
+    {
+      "name": "valid-minimal: only the required core raw-scan fields",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "loc": 100,
+          "files": 5,
+          "commits_window": 2,
+          "ai_commits_window": 1,
+          "additions_window": 20,
+          "deletions_window": 3,
+          "recent_commits": [],
+          "has_claude_md": false,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 0,
+          "commands_count": 0
+        }
+      }
+    },
+    {
+      "name": "valid-health-clean-pass: passing health snapshot with empty failed_invariant_ids",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+          "loc": 500,
+          "files": 20,
+          "commits_window": 5,
+          "ai_commits_window": 2,
+          "additions_window": 100,
+          "deletions_window": 10,
+          "recent_commits": [
+            {
+              "sha": "ffff000",
+              "author": "Sam",
+              "ai": false
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": true,
+          "agents_md_count": 1,
+          "skills_count": 2,
+          "commands_count": 1,
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z"
+          }
+        }
+      }
+    },
+    {
+      "name": "valid-1.22-coverage-denominator: the six new measures, coherent",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": 60.25,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          },
+          "test_coverage_lines_total": 10647,
+          "test_coverage_lines_covered": 6415,
+          "tests_total": 451,
+          "tests_passed": 451,
+          "tests_skipped": 0,
+          "tests_failed": 0
+        }
+      }
+    },
+    {
+      "name": "valid-1.22-explicit-nulls: unknown is a sendable value, and is not zero",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": 99,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          },
+          "test_coverage_lines_total": null,
+          "test_coverage_lines_covered": null,
+          "tests_total": null,
+          "tests_passed": null,
+          "tests_skipped": null,
+          "tests_failed": null
+        }
+      }
+    },
+    {
+      "name": "valid-1.24-scanner-identity: the scan declares which build produced it",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": 60.25,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          },
+          "test_coverage_lines_total": 10647,
+          "test_coverage_lines_covered": 6415,
+          "tests_total": 451,
+          "tests_passed": 451,
+          "tests_skipped": 0,
+          "tests_failed": 0,
+          "scanner_version": "0.2.0",
+          "scanner_sha": "8c29919236e602af63508abf5e988d4ab1d97eff"
+        }
+      }
+    },
+    {
+      "name": "valid-1.24-scanner-version-without-sha: a package install has no git history",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": 60.25,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          },
+          "test_coverage_lines_total": 10647,
+          "test_coverage_lines_covered": 6415,
+          "tests_total": 451,
+          "tests_passed": 451,
+          "tests_skipped": 0,
+          "tests_failed": 0,
+          "scanner_version": "0.2.0",
+          "scanner_sha": null
+        }
+      }
+    },
+    {
+      "name": "valid-1.24-scanner-identity-explicit-null: unknown build is a sendable value, and is not 'current'",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": 60.25,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          },
+          "test_coverage_lines_total": 10647,
+          "test_coverage_lines_covered": 6415,
+          "tests_total": 451,
+          "tests_passed": 451,
+          "tests_skipped": 0,
+          "tests_failed": 0,
+          "scanner_version": null,
+          "scanner_sha": null
+        }
+      }
+    },
+    {
+      "name": "valid-1.24-scanner-version-unparseable: a version the brain cannot read must NOT 422 the scan",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": 60.25,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          },
+          "test_coverage_lines_total": 10647,
+          "test_coverage_lines_covered": 6415,
+          "tests_total": 451,
+          "tests_passed": 451,
+          "tests_skipped": 0,
+          "tests_failed": 0,
+          "scanner_version": "nightly",
+          "scanner_sha": null
+        }
+      }
+    },
+    {
+      "name": "valid-v2-unchanged",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "2",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "complete",
+            "quality_gate": "pass",
+            "automation_eligible": true,
+            "findings": []
+          }
+        }
+      }
+    },
+    {
+      "name": "valid-v3-complete",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "complete",
+            "quality_gate": "pass",
+            "automation_eligible": true,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 4,
+                "complete": 4,
+                "partial": 0,
+                "missing": 0,
+                "stale": 0,
+                "error": 0
+              },
+              "required": {
+                "configured": 2,
+                "complete": 2,
+                "partial": 0,
+                "missing": 0,
+                "stale": 0,
+                "error": 0
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "valid-v3-mixed",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "valid-v3-zero",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "complete",
+            "quality_gate": "pass",
+            "automation_eligible": true,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 0,
+                "complete": 0,
+                "partial": 0,
+                "missing": 0,
+                "stale": 0,
+                "error": 0
+              },
+              "required": {
+                "configured": 0,
+                "complete": 0,
+                "partial": 0,
+                "missing": 0,
+                "stale": 0,
+                "error": 0
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "valid-v3-required-subset",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 8,
+                "complete": 3,
+                "partial": 2,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 4,
+                "complete": 2,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "name": "invalid-sparse-health-only: codebase_health without the full raw-metrics block",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          }
+        }
+      }
+    },
+    {
+      "name": "invalid-bad-health-types: wrong scalar types inside codebase_health",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "loc": 100,
+          "files": 5,
+          "commits_window": 2,
+          "ai_commits_window": 1,
+          "additions_window": 20,
+          "deletions_window": 3,
+          "recent_commits": [],
+          "has_claude_md": false,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 0,
+          "commands_count": 0,
+          "codebase_health": {
+            "schema_version": 1,
+            "rubric_version": "1.0.0",
+            "head_sha": "not-a-sha",
+            "score_pct": "eighty",
+            "status": "amber",
+            "dimensions": {
+              "structure": {
+                "passed": "four",
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": "OGR04.tier-coverage",
+            "measured_at": "yesterday"
+          }
+        }
+      }
+    },
+    {
+      "name": "invalid-health-missing-required: codebase_health without status/measured_at",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "loc": 100,
+          "files": 5,
+          "commits_window": 2,
+          "ai_commits_window": 1,
+          "additions_window": 20,
+          "deletions_window": 3,
+          "recent_commits": [],
+          "has_claude_md": false,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 0,
+          "commands_count": 0,
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": []
+          }
+        }
+      }
+    },
+    {
+      "name": "invalid-health-unknown-key: codebase_health smuggling a non-scalar surface (file path)",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "loc": 100,
+          "files": 5,
+          "commits_window": 2,
+          "ai_commits_window": 1,
+          "additions_window": 20,
+          "deletions_window": 3,
+          "recent_commits": [],
+          "has_claude_md": false,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 0,
+          "commands_count": 0,
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "failing_files": [
+              "5-personal/notes.md"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "invalid-missing-metrics: payload without the metrics block at all",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo"
+        }
+      }
+    },
+    {
+      "name": "invalid-empty-dimensions: dimensions map may not be empty",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "loc": 100,
+          "files": 5,
+          "commits_window": 2,
+          "ai_commits_window": 1,
+          "additions_window": 20,
+          "deletions_window": 3,
+          "recent_commits": [],
+          "has_claude_md": false,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 0,
+          "commands_count": 0,
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {},
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z"
+          }
+        }
+      }
+    },
+    {
+      "name": "invalid-1.22-negative-denominator: a count below zero is not a measurement",
+      "reason": "test_coverage_lines_total/_covered are integers >= 0; the brain's schema is nonnegative, so a canonical contract that accepted these would license a payload the brain 422s - losing the whole scan, not just the field.",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": 99,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          },
+          "test_coverage_lines_total": -1,
+          "test_coverage_lines_covered": -2
+        }
+      }
+    },
+    {
+      "name": "invalid-1.22-negative-skipped: same rule for the run-integrity counts",
+      "reason": "tests_* are integers >= 0.",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          },
+          "tests_total": 10,
+          "tests_skipped": -1
+        }
+      }
+    },
+    {
+      "name": "invalid-1.22-fractional-count: these are counts, not percentages",
+      "reason": "test_coverage_lines_total must be an integer.",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          },
+          "test_coverage_lines_total": 100.5
+        }
+      }
+    },
+    {
+      "name": "invalid-1.23-fix-analysis-on-feature: fix evidence requires a fix classification",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "loc": 100,
+          "files": 5,
+          "commits_window": 1,
+          "ai_commits_window": 0,
+          "additions_window": 3,
+          "deletions_window": 2,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "feat"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 2,
+                "blamed_parent_lines": 2,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 0,
+                  "8_30d": 0,
+                  "31_90d": 0,
+                  "91_365d": 0,
+                  "366d_plus": 0
+                },
+                "prior_fix_parent_lines": 0
+              }
+            }
+          ],
+          "has_claude_md": false,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 0,
+          "commands_count": 0
+        }
+      }
+    },
+    {
+      "name": "invalid-1.24-scanner-version-not-a-string: identity is a string or null, never a number",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": 60.25,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          },
+          "test_coverage_lines_total": 10647,
+          "test_coverage_lines_covered": 6415,
+          "tests_total": 451,
+          "tests_passed": 451,
+          "tests_skipped": 0,
+          "tests_failed": 0,
+          "scanner_version": 2
+        }
+      }
+    },
+    {
+      "name": "invalid-1.24-scanner-sha-overlong: bounded because it becomes a stored column",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z"
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": 60.25,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "1.0",
+            "rubric_version": "1.0.0",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
+            "score_pct": 87.5,
+            "status": "warn",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4
+              },
+              "governance": {
+                "passed": 3,
+                "total": 4
+              }
+            },
+            "failed_invariant_ids": [
+              "OGR04.tier-coverage"
+            ],
+            "measured_at": "2026-07-30T09:00:00Z"
+          },
+          "test_coverage_lines_total": 10647,
+          "test_coverage_lines_covered": 6415,
+          "tests_total": 451,
+          "tests_passed": 451,
+          "tests_skipped": 0,
+          "tests_failed": 0,
+          "scanner_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      }
+    },
+    {
+      "name": "v3-all-configured-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": -1,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-configured-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 1.5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-configured-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": "1",
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-configured-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": null,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-configured-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": true,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-configured-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": {},
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-configured-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": [],
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-configured-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-complete-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": -1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-complete-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1.5,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-complete-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": "1",
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-complete-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": null,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-complete-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": true,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-complete-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": {},
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-complete-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": [],
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-complete-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-partial-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": -1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-partial-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1.5,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-partial-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": "1",
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-partial-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": null,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-partial-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": true,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-partial-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": {},
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-partial-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": [],
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-partial-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-missing-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": -1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-missing-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1.5,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-missing-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": "1",
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-missing-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": null,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-missing-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": true,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-missing-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": {},
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-missing-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": [],
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-missing-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-stale-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": -1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-stale-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1.5,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-stale-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": "1",
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-stale-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": null,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-stale-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": true,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-stale-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": {},
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-stale-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": [],
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-stale-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-error-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": -1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-error-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1.5
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-error-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": "1"
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-error-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": null
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-error-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": true
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-error-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": {}
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-error-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": []
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-error-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-configured-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": -1,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-configured-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 1.5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-configured-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": "1",
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-configured-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": null,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-configured-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": true,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-configured-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": {},
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-configured-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": [],
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-configured-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-complete-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": -1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-complete-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1.5,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-complete-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": "1",
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-complete-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": null,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-complete-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": true,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-complete-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": {},
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-complete-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": [],
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-complete-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-partial-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": -1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-partial-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1.5,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-partial-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": "1",
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-partial-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": null,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-partial-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": true,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-partial-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": {},
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-partial-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": [],
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-partial-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-missing-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": -1,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-missing-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1.5,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-missing-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": "1",
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-missing-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": null,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-missing-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": true,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-missing-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": {},
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-missing-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": [],
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-missing-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-stale-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": -1,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-stale-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 1.5,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-stale-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": "1",
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-stale-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": null,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-stale-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": true,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-stale-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": {},
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-stale-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": [],
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-stale-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-error-type--1",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": -1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-error-type-1.5",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1.5
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-error-type-\"1\"",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": "1"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-error-type-null",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": null
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-error-type-true",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": true
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-error-type-{}",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-error-type-[]",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": []
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-error-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-path",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1,
+                "path": "forbidden"
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-source",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1,
+                "source": "forbidden"
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-prompt",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1,
+                "prompt": "forbidden"
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-contributor",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1,
+                "contributor": "forbidden"
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-unknown",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1,
+                "unknown": "forbidden"
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-path",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1,
+                "path": "forbidden"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-source",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1,
+                "source": "forbidden"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-prompt",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1,
+                "prompt": "forbidden"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-contributor",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1,
+                "contributor": "forbidden"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-unknown",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1,
+                "unknown": "forbidden"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-coverage-missing",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": []
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-coverage-extra",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              },
+              "path": "src/private.ts"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "brain_invalid": [
+    {
+      "name": "brain-invalid-1.23-blame-exceeds-candidates",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "loc": 100,
+          "files": 5,
+          "commits_window": 1,
+          "ai_commits_window": 0,
+          "additions_window": 3,
+          "deletions_window": 2,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 2,
+                "blamed_parent_lines": 3,
+                "age_buckets": {
+                  "0_1d": 3,
+                  "2_7d": 0,
+                  "8_30d": 0,
+                  "31_90d": 0,
+                  "91_365d": 0,
+                  "366d_plus": 0
+                },
+                "prior_fix_parent_lines": 0
+              }
+            }
+          ],
+          "has_claude_md": false,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 0,
+          "commands_count": 0
+        }
+      }
+    },
+    {
+      "name": "brain-invalid-1.23-age-buckets-do-not-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "loc": 100,
+          "files": 5,
+          "commits_window": 1,
+          "ai_commits_window": 0,
+          "additions_window": 3,
+          "deletions_window": 2,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 3,
+                "blamed_parent_lines": 3,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 0,
+                  "8_30d": 0,
+                  "31_90d": 0,
+                  "91_365d": 0,
+                  "366d_plus": 0
+                },
+                "prior_fix_parent_lines": 0
+              }
+            }
+          ],
+          "has_claude_md": false,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 0,
+          "commands_count": 0
+        }
+      }
+    },
+    {
+      "name": "brain-invalid-1.23-prior-fix-exceeds-blamed",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "loc": 100,
+          "files": 5,
+          "commits_window": 1,
+          "ai_commits_window": 0,
+          "additions_window": 3,
+          "deletions_window": 2,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 3,
+                "blamed_parent_lines": 2,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 0,
+                  "8_30d": 0,
+                  "31_90d": 0,
+                  "91_365d": 0,
+                  "366d_plus": 0
+                },
+                "prior_fix_parent_lines": 3
+              }
+            }
+          ],
+          "has_claude_md": false,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 0,
+          "commands_count": 0
+        }
+      }
+    }
+  ],
+  "scanner_state": {
+    "_note": "Consumer conformance vectors for the brain-api 1.24 scanner-identity READING (AIO-1011). JSON Schema pins the WIRE shape of metrics.scanner_version; these pin what a reader must CONCLUDE from it, which the schema cannot express. Three states and no fourth - unknown | stale | current - compared against codebasePayloadContract.minScannerVersion in brain-contract.json. The load-bearing rule: absent, null and unparseable are UNKNOWN, never stale. \"The scan did not tell us\" is a different statement from \"the scan told us it is old\", and collapsing them is the exact defect 1.24 exists to remove - absence of evidence rendered as evidence. Note also that unknown is NOT a synonym for \"predates 1.24\": a current scanner that cannot determine its own build is required to send null too. PARSEABLE is defined narrowly and normatively in docs/brain-api.md beneath each truth table - exactly three dotted non-negative integers, nothing else - so a leading v, a two-part version, a channel name, and any SemVer pre-release or build suffix are unreadable and therefore unknown. That choice fails safe (an unrecognised build is a caveat, never a pass) and is pinned by the vectors below rather than left implied. A vector with no scanner_version key means the field was ABSENT from the payload. THESE VECTORS ARE THE ENFORCEMENT SURFACE: a consumer is conformant only by running them against its own real classifier - the workspace side merely checks they are self-consistent.",
+    "vectors": [
+      {
+        "name": "absent: a pre-1.24 scan never sent the field and can never be backfilled",
+        "state": "unknown"
+      },
+      {
+        "name": "null: the scanner could not determine its own build and said so",
+        "scanner_version": null,
+        "state": "unknown"
+      },
+      {
+        "name": "empty string: unreadable, so unknown — and still not a 422",
+        "scanner_version": "",
+        "state": "unknown"
+      },
+      {
+        "name": "unparseable: a fork or local build emits something that is not a version",
+        "scanner_version": "not a version at all",
+        "state": "unknown"
+      },
+      {
+        "name": "unparseable channel name, not a version",
+        "scanner_version": "nightly",
+        "state": "unknown"
+      },
+      {
+        "name": "pre-release suffix: SemVer orders it BEFORE 0.2.0, so it is not evidence of currency",
+        "scanner_version": "0.2.0-rc1",
+        "state": "unknown"
+      },
+      {
+        "name": "build suffix: unreadable under the published grammar, so unknown - never falsely current",
+        "scanner_version": "0.2.0+dirty",
+        "state": "unknown"
+      },
+      {
+        "name": "malformed suffix: a dangling separator is not a version",
+        "scanner_version": "0.2.0-",
+        "state": "unknown"
+      },
+      {
+        "name": "leading v: unreadable, and must not be silently normalised into a match",
+        "scanner_version": "v0.2.0",
+        "state": "unknown"
+      },
+      {
+        "name": "two-part version: not three dotted integers, so unreadable",
+        "scanner_version": "0.2",
+        "state": "unknown"
+      },
+      {
+        "name": "BELOW-minimum prefix with an unreadable suffix: must NOT fall through to stale - reading 0.1.0 out of a string the parser just failed on is a verdict from a measurement never made",
+        "scanner_version": "0.1.0-rc.1",
+        "state": "unknown"
+      },
+      {
+        "name": "four components: more than three integers is not the published grammar",
+        "scanner_version": "1.0.0.0",
+        "state": "unknown"
+      },
+      {
+        "name": "below the declared minimum: the one case that is genuinely STALE",
+        "scanner_version": "0.1.0",
+        "state": "stale"
+      },
+      {
+        "name": "below the declared minimum on the patch component",
+        "scanner_version": "0.1.9",
+        "state": "stale"
+      },
+      {
+        "name": "exactly the declared minimum: at-or-above is current, the boundary is inclusive",
+        "scanner_version": "0.2.0",
+        "state": "current"
+      },
+      {
+        "name": "above the declared minimum on patch",
+        "scanner_version": "0.2.1",
+        "state": "current"
+      },
+      {
+        "name": "above the declared minimum on major",
+        "scanner_version": "1.0.0",
+        "state": "current"
+      }
+    ]
+  },
+  "coverage_invalid": [
+    {
+      "name": "v3-all-configured-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 6,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-complete-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 2,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-partial-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 2,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-missing-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 2,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-stale-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 2,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-all-error-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 2
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-configured-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 4,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-complete-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 2,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-partial-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 2,
+                "missing": 0,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-missing-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 0,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-stale-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 1,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-error-sum",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 1,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 2
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-exceeds-all",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 6,
+                "complete": 2,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "v3-required-status-exceeds-all",
+      "payload": {
+        "codebase": {
+          "slug": "synthetic-repo",
+          "full_name": "synthetic-org/synthetic-repo",
+          "provider": "github"
+        },
+        "metrics": {
+          "head_sha": "abc123def456abc123def456abc123def456abc1",
+          "window_days": 90,
+          "loc": 12000,
+          "files": 240,
+          "commits_window": 40,
+          "ai_commits_window": 18,
+          "additions_window": 3200,
+          "deletions_window": 900,
+          "recent_commits": [
+            {
+              "sha": "abc123d",
+              "author": "Alex",
+              "ai": true,
+              "committed_at": "2026-07-29T10:00:00Z",
+              "commit_classification": {
+                "scheme": "conventional-commit-v1",
+                "type": "fix"
+              },
+              "fix_analysis": {
+                "method": "first-parent-line-blame-v1",
+                "candidate_parent_lines": 42,
+                "blamed_parent_lines": 39,
+                "age_buckets": {
+                  "0_1d": 2,
+                  "2_7d": 6,
+                  "8_30d": 8,
+                  "31_90d": 9,
+                  "91_365d": 10,
+                  "366d_plus": 4
+                },
+                "prior_fix_parent_lines": 7
+              }
+            }
+          ],
+          "has_claude_md": true,
+          "has_agents_md": false,
+          "agents_md_count": 0,
+          "skills_count": 7,
+          "commands_count": 3,
+          "test_coverage_pct": null,
+          "readiness_level": "L3",
+          "readiness_pct": 61.11,
+          "readiness_pillars": {
+            "testing": {
+              "passed": 2,
+              "total": 2
+            },
+            "docs": {
+              "passed": 2,
+              "total": 3
+            }
+          },
+          "readiness_rubric_version": "1.0.0",
+          "codebase_health": {
+            "schema_version": "3",
+            "rubric_version": "1.0.0",
+            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "score_pct": 100,
+            "status": "pass",
+            "dimensions": {
+              "structure": {
+                "passed": 4,
+                "total": 4,
+                "band": 4,
+                "evidence_status": "complete"
+              }
+            },
+            "failed_invariant_ids": [],
+            "measured_at": "2026-07-30T09:00:00Z",
+            "profile_id": "synthetic",
+            "profile_version": "1",
+            "evidence_status": "partial",
+            "quality_gate": "unknown",
+            "automation_eligible": false,
+            "findings": [],
+            "check_coverage": {
+              "all": {
+                "configured": 5,
+                "complete": 1,
+                "partial": 1,
+                "missing": 1,
+                "stale": 1,
+                "error": 1
+              },
+              "required": {
+                "configured": 3,
+                "complete": 2,
+                "partial": 1,
+                "missing": 0,
+                "stale": 0,
+                "error": 0
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Health v3 would update the scan census while silently bypassing the existing finding ledger. This prerequisite makes the same SQL RPC admit v2/v3 and order latest evidence across both, preserving exact stored-object identity, team/codebase/head checks, locking and lifecycle behavior.

The additive function migration matches bootstrap. The coverage consumer still owns the public schema and wrapper activation; The producer slice owns emission. The existing separate metrics/RPC transaction boundary remains: a superseded concurrent same-head submission can fail identity verification. This change does not relax it.

Validation: full spec gate SPEC_READY 100 on a clean staging base; independent schema/spec review CLEAR. 21 real-Postgres checks pass; 23 focused guards and 5,906 full-suite tests pass (2 expected failures, 16 skips). Real Postgres covers v2/v3 lifecycle, replay, mixed-version ordering, identity rejection, bootstrap/upgrade function equivalence, unchanged grants/dependencies, and disposable rollback/reapply. Both old-predicate mutations REDDENED their intended tests. Typecheck, lint (zero errors), docs drift and focused migration/ledger guards passed.

Rollback before activation can restore the old function through a reviewed forward migration. After activation retain this compatible RPC or disable v3 emission before rollback; never delete evidence or manually load production schema. Staging deployment/migration evidence and controlled production release are tracked by the orchestrator; this PR alone does not activate v3.

## Review — Reviewed by gpt-6-astra — verdict CLEAR at 194017a8e141e0887206417b499934268f8cc55f

Independent Astra review caught an upgrade-test baseline pointing at the original ledger definition rather than its latest override. Corrected to `20260804160000_explainable_debt_decisions.sql`; Astra verified the final one-line delta and the real-Postgres suite passed again. Production SQL already matched the current baseline. No unresolved findings.

Mutation results (each restored independently):

```
mutate: REDDENED
  red: health v3 SQL compatibility v3 detects, reobserves, resolves and reopens with replay idempotence
  tests run: 9
```

```
mutate: REDDENED
  red: health v3 SQL compatibility older v2 cannot become active after a newer v3 clean scan
  red: health v3 SQL compatibility older v3 cannot become active after a newer v3 clean scan
  tests run: 9
```

AIOS-Work: AIO-1171
