### PR TITLE
feat(codebases): preserve and display scanner check coverage

### DIFF
--- a/app/t/[team]/codebases/[slug]/page.tsx
+++ b/app/t/[team]/codebases/[slug]/page.tsx
@@ -158,7 +158,7 @@ export default async function CodebaseDetailPage({
         health={cb.breakdown?.codebase_health ?? null}
         healthStale={isCodebaseStale(
           cb.breakdown?.codebase_health?.measured_at ?? null,
-          Date.now(),
+          Date.parse(cb.debtKpis.movement.asOf),
         )}
       />
 

--- a/app/t/[team]/codebases/[slug]/page.tsx
+++ b/app/t/[team]/codebases/[slug]/page.tsx
@@ -1,20 +1,32 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, Star, GitFork, CircleDot, ChevronRight } from "lucide-react";
+import {
+  ArrowLeft,
+  Star,
+  GitFork,
+  CircleDot,
+  ChevronRight,
+} from "lucide-react";
 import { serverClient } from "@/lib/db/server";
 import { currentMember } from "@/lib/auth/guard";
-import { getCodebaseDetail } from "@/lib/metrics/codebases";
+import { getCodebaseDetail, isCodebaseStale } from "@/lib/metrics/codebases";
 import { parseRange } from "@/lib/metrics/range";
 import { timeAgo } from "@/components/format";
 import { RangeSelector } from "@/components/dashboard/range-selector";
-import { AgenticScoreCard, AgentReadinessCard } from "@/components/codebases/agentic-breakdown";
+import {
+  AgenticScoreCard,
+  AgentReadinessCard,
+} from "@/components/codebases/agentic-breakdown";
 import { ContributorTable } from "@/components/codebases/contributor-table";
 import { IssuesList } from "@/components/codebases/issues-list";
 import { AgenticTrend } from "@/components/charts/agentic-trend";
 import { ContributionsTrend } from "@/components/charts/contributions-trend";
 import { DebtPatrol } from "@/components/codebases/debt-patrol";
-import { DebtEvidence, DebtMovement } from "@/components/codebases/debt-dashboard";
+import {
+  DebtEvidence,
+  DebtMovement,
+} from "@/components/codebases/debt-dashboard";
 
 export const metadata: Metadata = { title: "Codebase" };
 
@@ -25,12 +37,15 @@ export default async function CodebaseDetailPage({
   params: Promise<{ team: string; slug: string }>;
   searchParams: Promise<{ range?: string }>;
 }) {
-
   const { team: teamSlug, slug } = await params;
   const range = parseRange((await searchParams).range);
   const db = await serverClient();
 
-  const { data: team } = await db.from("teams").select("id").eq("slug", teamSlug).maybeSingle();
+  const { data: team } = await db
+    .from("teams")
+    .select("id")
+    .eq("slug", teamSlug)
+    .maybeSingle();
   if (!team) return null;
 
   const me = await currentMember(team.id);
@@ -67,11 +82,16 @@ export default async function CodebaseDetailPage({
               </a>
             ) : null}
             {cb.description ? (
-              <p className="mt-1 max-w-2xl text-sm text-ink-secondary">{cb.description}</p>
+              <p className="mt-1 max-w-2xl text-sm text-ink-secondary">
+                {cb.description}
+              </p>
             ) : null}
             <div className="mt-2 flex flex-wrap items-center gap-3 text-[11px] text-ink-tertiary">
               {langs.map((l) => (
-                <span key={l} className="rounded-full border border-border-subtle px-2 py-0.5">
+                <span
+                  key={l}
+                  className="rounded-full border border-border-subtle px-2 py-0.5"
+                >
                   {l}
                 </span>
               ))}
@@ -98,7 +118,8 @@ export default async function CodebaseDetailPage({
                   }`}
                   title={`workspace-health rubric ${cb.breakdown.codebase_health.rubric_version}`}
                 >
-                  workspace health {Math.round(cb.breakdown.codebase_health.score_pct)}% ·{" "}
+                  workspace health{" "}
+                  {Math.round(cb.breakdown.codebase_health.score_pct)}% ·{" "}
                   {cb.breakdown.codebase_health.status} · measured{" "}
                   {timeAgo(cb.breakdown.codebase_health.measured_at)}
                 </span>
@@ -112,8 +133,9 @@ export default async function CodebaseDetailPage({
       {cb.stale ? (
         <div className="rounded-lg border border-amber-400/25 bg-amber-400/10 px-4 py-2.5 text-xs text-amber-600 dark:text-amber-300">
           No recent scan — the scores below are from the last scan{" "}
-          {cb.last_scan_at ? timeAgo(cb.last_scan_at) : ""}. Contribution and commit-volume charts
-          only cover the selected range, so they may be empty until this repo is re-scanned.
+          {cb.last_scan_at ? timeAgo(cb.last_scan_at) : ""}. Contribution and
+          commit-volume charts only cover the selected range, so they may be
+          empty until this repo is re-scanned.
         </div>
       ) : null}
 
@@ -131,7 +153,14 @@ export default async function CodebaseDetailPage({
         )
       ) : null}
 
-      <DebtMovement debt={cb.debtKpis} />
+      <DebtMovement
+        debt={cb.debtKpis}
+        health={cb.breakdown?.codebase_health ?? null}
+        healthStale={isCodebaseStale(
+          cb.breakdown?.codebase_health?.measured_at ?? null,
+          Date.now(),
+        )}
+      />
 
       <DebtPatrol
         patrol={cb.debtPatrol}
@@ -140,7 +169,9 @@ export default async function CodebaseDetailPage({
         teamSlug={teamSlug}
         codebaseSlug={cb.slug}
         currentMemberId={me.id}
-        canDecide={me.tier === "team" && (me.role === "admin" || me.role === "lead")}
+        canDecide={
+          me.tier === "team" && (me.role === "admin" || me.role === "lead")
+        }
       />
 
       <DebtEvidence debt={cb.debtKpis} />
@@ -151,7 +182,11 @@ export default async function CodebaseDetailPage({
         <h2 className="text-sm font-semibold uppercase tracking-wider text-ink-tertiary">
           Contributors
         </h2>
-        <ContributorTable rows={cb.contributors} teamSlug={teamSlug} codebaseSlug={cb.slug} />
+        <ContributorTable
+          rows={cb.contributors}
+          teamSlug={teamSlug}
+          codebaseSlug={cb.slug}
+        />
       </section>
 
       {/* Issues & PRs collapsed by default (native <details> — no client JS). */}
@@ -159,7 +194,9 @@ export default async function CodebaseDetailPage({
         <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-semibold uppercase tracking-wider text-ink-tertiary hover:text-ink-secondary">
           <ChevronRight className="size-4 shrink-0 transition-transform group-open:rotate-90" />
           Issues &amp; PRs
-          <span className="font-normal normal-case text-ink-tertiary/70">({cb.issues.length})</span>
+          <span className="font-normal normal-case text-ink-tertiary/70">
+            ({cb.issues.length})
+          </span>
         </summary>
         <div className="mt-3">
           <IssuesList issues={cb.issues} />

--- a/components/codebases/debt-dashboard.tsx
+++ b/components/codebases/debt-dashboard.tsx
@@ -1,3 +1,4 @@
+import type { CodebaseHealth } from "@/lib/api/schemas";
 import type {
   CodebaseDebtKpis,
   FixAgeBucket,
@@ -107,7 +108,157 @@ function EvidenceGap({ label, reason }: { label: string; reason: string }) {
   );
 }
 
-export function DebtMovement({ debt }: { debt: CodebaseDebtKpis }) {
+export function ScannerCheckCoverage({
+  health,
+  stale,
+}: {
+  health: CodebaseHealth | null;
+  stale: boolean;
+}) {
+  const v3 =
+    health?.schema_version === "3" && "check_coverage" in health
+      ? health
+      : null;
+  const flags: string[] = [];
+  if (v3) {
+    const all = v3.check_coverage.all;
+    if (stale || all.stale > 0 || v3.evidence_status === "stale")
+      flags.push("Stale scan");
+    if (all.error > 0 || v3.evidence_status === "error")
+      flags.push("Error evidence");
+    if (all.complete < all.configured || v3.evidence_status !== "complete")
+      flags.push("Partial scan");
+    if (all.configured === 0) flags.push("No configured checks");
+    else if (flags.length === 0) flags.push("Complete scan");
+  }
+  return (
+    <section
+      aria-labelledby="scanner-check-coverage-heading"
+      className="border-t border-border-subtle py-5"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-3">
+        <h2
+          id="scanner-check-coverage-heading"
+          className="text-base font-semibold text-ink"
+        >
+          Scanner check coverage
+        </h2>
+        <p className="text-sm font-medium text-ink-secondary">
+          {v3 ? flags.join(" · ") : "Coverage unknown"}
+        </p>
+      </div>
+      <p className="mt-2 text-xs leading-5 text-ink-secondary">
+        {v3
+          ? "Health v3 census available. Each configured check is counted once; findings emitted may be zero or many per check."
+          : "No health v3 census is available. Legacy or absent health data does not establish configured check coverage."}
+      </p>
+      {v3 ? (
+        <>
+          <dl className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-3">
+            {[
+              ["Configured checks", v3.check_coverage.all.configured],
+              [
+                "Complete required",
+                `${v3.check_coverage.required.complete} / ${v3.check_coverage.required.configured}`,
+              ],
+              ["Findings emitted", v3.findings.length],
+            ].map(([label, value]) => (
+              <div key={label} className="min-w-0">
+                <dt className="text-xs text-ink-secondary">{label}</dt>
+                <dd className="mt-1 font-mono text-xl tabular-nums text-ink">
+                  {value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+          <table className="mt-4 w-full text-left text-xs text-ink-secondary">
+            <caption className="sr-only">
+              Configured check census by evidence state
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col" className="py-2 font-medium">
+                  Evidence state
+                </th>
+                <th scope="col" className="py-2 text-right font-medium">
+                  All checks
+                </th>
+                <th scope="col" className="py-2 text-right font-medium">
+                  Required checks
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {(
+                [
+                  "configured",
+                  "complete",
+                  "partial",
+                  "missing",
+                  "stale",
+                  "error",
+                ] as const
+              ).map((status) => (
+                <tr key={status} className="border-t border-border-subtle">
+                  <th scope="row" className="py-2 font-normal">
+                    {status[0].toUpperCase() + status.slice(1)}
+                  </th>
+                  <td className="py-2 text-right font-mono tabular-nums">
+                    {v3.check_coverage.all[status]}
+                  </td>
+                  <td className="py-2 text-right font-mono tabular-nums">
+                    {v3.check_coverage.required[status]}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <dl className="mt-4 grid gap-x-6 gap-y-3 border-t border-border-subtle pt-4 text-xs sm:grid-cols-2">
+            <div className="min-w-0">
+              <dt className="font-medium text-ink-secondary">Profile</dt>
+              <dd className="mt-1 break-all text-ink-secondary">
+                {v3.profile_id} · {v3.profile_version}
+              </dd>
+            </div>
+            <div className="min-w-0">
+              <dt className="font-medium text-ink-secondary">Rubric</dt>
+              <dd className="mt-1 break-all text-ink-secondary">
+                {v3.rubric_version}
+              </dd>
+            </div>
+            <div className="min-w-0">
+              <dt className="font-medium text-ink-secondary">Head</dt>
+              <dd className="mt-1 break-all font-mono text-ink-secondary">
+                {v3.head_sha}
+              </dd>
+            </div>
+            <div className="min-w-0">
+              <dt className="font-medium text-ink-secondary">Measured time</dt>
+              <dd className="mt-1 break-all text-ink-secondary">
+                <time dateTime={v3.measured_at}>{v3.measured_at}</time>
+              </dd>
+            </div>
+          </dl>
+        </>
+      ) : (
+        <p className="mt-3 text-xs text-ink-secondary">
+          Configured checks: Unknown · Complete required: Unknown · Findings
+          emitted: Unknown
+        </p>
+      )}
+    </section>
+  );
+}
+
+export function DebtMovement({
+  debt,
+  health = null,
+  healthStale = true,
+}: {
+  debt: CodebaseDebtKpis;
+  health?: CodebaseHealth | null;
+  healthStale?: boolean;
+}) {
   const { movement } = debt;
   const openAgeRows: Array<{ key: string; label: string; value: number }> =
     OPEN_AGE_LABELS.map(([key, label]) => ({
@@ -131,129 +282,133 @@ export function DebtMovement({ debt }: { debt: CodebaseDebtKpis }) {
   );
 
   return (
-    <section
-      aria-labelledby="debt-movement-heading"
-      className="border-y border-border-subtle py-5"
-    >
-      <div className="flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-tertiary">
-            Scanner-admitted debt
-          </p>
-          <h2
-            id="debt-movement-heading"
-            className="mt-1 font-display text-xl text-ink text-balance"
-          >
-            What has the deterministic health scanner admitted?
-          </h2>
-          <p className="mt-2 max-w-3xl text-xs leading-5 text-ink-tertiary">
-            This section is derived only from scanner-admitted findings and
-            their lifecycle events — what the configured deterministic health
-            scanner admitted into the ledger — and is not a count of all
-            defects in this codebase.
-          </p>
-        </div>
-        <p className="text-xs text-ink-tertiary">
-          Stock as of {new Date(movement.asOf).toLocaleDateString()} · flow in
-          selected range
-        </p>
-      </div>
-
-      <div className="mt-5 grid gap-5 lg:grid-cols-[0.9fr_1.1fr]">
-        <div className="border-b border-border-subtle pb-5 lg:border-r lg:border-b-0 lg:pr-5 lg:pb-0">
-          <dl className="grid grid-cols-2 gap-x-5">
-            <Metric
-              label="Active scanner findings"
-              value={movement.actionable}
-              detail={`${movement.actionableOpen} open · ${movement.actionableReopened} reopened`}
-              tone="arrival"
-            />
-            <Metric
-              label="Suppressed"
-              value={movement.suppressed}
-              detail={`${movement.suppressions.accepted} accepted · ${movement.suppressions.riskAccepted} risk · ${movement.suppressions.falsePositive} false positive`}
-            />
-          </dl>
-          {movement.expiryReturnsToActionable > 0 ? (
-            <p className="border-t border-border-subtle pt-3 text-xs leading-5 text-ink-tertiary">
-              {movement.expiryReturnsToActionable} expired decision
-              {movement.expiryReturnsToActionable === 1 ? " is" : "s are"}{" "}
-              actionable again. Expiry flow is not emitted as a ledger event, so
-              it is excluded from arrivals.
-            </p>
-          ) : null}
-        </div>
-
-        <dl className="grid grid-cols-3 gap-x-5">
-          <Metric
-            label="Arrivals"
-            value={movement.arrivals}
-            detail={`${movement.detected} detected · ${movement.reopened} reopened`}
-            tone="arrival"
-          />
-          <Metric
-            label="Closures"
-            value={movement.closures}
-            detail="Resolved transitions only"
-            tone="closure"
-          />
-          <Metric
-            label="Net flow"
-            value={`${movement.netFlow > 0 ? "+" : ""}${movement.netFlow}`}
-            detail={
-              movement.netFlow > 0
-                ? "Stock grew"
-                : movement.netFlow < 0
-                  ? "Stock shrank"
-                  : "Flat"
-            }
-            tone={
-              movement.netFlow > 0
-                ? "regression"
-                : movement.netFlow < 0
-                  ? "closure"
-                  : "neutral"
-            }
-          />
-        </dl>
-      </div>
-
-      <div className="mt-5 grid gap-5 border-t border-border-subtle pt-5 md:grid-cols-2">
-        <div>
-          <h3 className="mb-3 text-xs font-semibold text-ink-secondary">
-            Open age
-          </h3>
-          <Distribution
-            label="Active scanner findings by open-age bucket"
-            rows={openAgeRows}
-            total={movement.actionable}
-            colorClass="bg-amber-500"
-          />
-        </div>
-        <div>
-          <h3 className="mb-3 text-xs font-semibold text-ink-secondary">
-            Current severity
-          </h3>
-          <Distribution
-            label="Active scanner findings by current severity"
-            rows={severityRows}
-            total={movement.actionable}
-            colorClass="bg-red-500"
-          />
-          <p className="mt-3 text-[11px] leading-4 text-ink-tertiary">
-            Historical severity is unavailable until finding events carry
-            event-time snapshots.
-          </p>
-        </div>
-      </div>
-
+    <>
       <div className="mt-5">
         <EvidenceGap
           label="UltraHarden intake"
           reason="candidate intake is not connected yet, so candidates that were rejected, deduplicated, or never filed do not appear here"
         />
       </div>
-    </section>
+      <ScannerCheckCoverage health={health} stale={healthStale} />
+      <section
+        aria-labelledby="debt-movement-heading"
+        className="border-y border-border-subtle py-5"
+      >
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-tertiary">
+              Scanner-admitted debt
+            </p>
+            <h2
+              id="debt-movement-heading"
+              className="mt-1 font-display text-xl text-ink text-balance"
+            >
+              What has the deterministic health scanner admitted?
+            </h2>
+            <p className="mt-2 max-w-3xl text-xs leading-5 text-ink-tertiary">
+              This section is derived only from scanner-admitted findings and
+              their lifecycle events — what the configured deterministic health
+              scanner admitted into the ledger — and is not a count of all
+              defects in this codebase.
+            </p>
+          </div>
+          <p className="text-xs text-ink-tertiary">
+            Stock as of {new Date(movement.asOf).toLocaleDateString()} · flow in
+            selected range
+          </p>
+        </div>
+
+        <div className="mt-5 grid gap-5 lg:grid-cols-[0.9fr_1.1fr]">
+          <div className="border-b border-border-subtle pb-5 lg:border-r lg:border-b-0 lg:pr-5 lg:pb-0">
+            <dl className="grid grid-cols-2 gap-x-5">
+              <Metric
+                label="Active scanner findings"
+                value={movement.actionable}
+                detail={`${movement.actionableOpen} open · ${movement.actionableReopened} reopened`}
+                tone="arrival"
+              />
+              <Metric
+                label="Suppressed"
+                value={movement.suppressed}
+                detail={`${movement.suppressions.accepted} accepted · ${movement.suppressions.riskAccepted} risk · ${movement.suppressions.falsePositive} false positive`}
+              />
+            </dl>
+            {movement.expiryReturnsToActionable > 0 ? (
+              <p className="border-t border-border-subtle pt-3 text-xs leading-5 text-ink-tertiary">
+                {movement.expiryReturnsToActionable} expired decision
+                {movement.expiryReturnsToActionable === 1
+                  ? " is"
+                  : "s are"}{" "}
+                actionable again. Expiry flow is not emitted as a ledger event,
+                so it is excluded from arrivals.
+              </p>
+            ) : null}
+          </div>
+
+          <dl className="grid grid-cols-3 gap-x-5">
+            <Metric
+              label="Arrivals"
+              value={movement.arrivals}
+              detail={`${movement.detected} detected · ${movement.reopened} reopened`}
+              tone="arrival"
+            />
+            <Metric
+              label="Closures"
+              value={movement.closures}
+              detail="Resolved transitions only"
+              tone="closure"
+            />
+            <Metric
+              label="Net flow"
+              value={`${movement.netFlow > 0 ? "+" : ""}${movement.netFlow}`}
+              detail={
+                movement.netFlow > 0
+                  ? "Stock grew"
+                  : movement.netFlow < 0
+                    ? "Stock shrank"
+                    : "Flat"
+              }
+              tone={
+                movement.netFlow > 0
+                  ? "regression"
+                  : movement.netFlow < 0
+                    ? "closure"
+                    : "neutral"
+              }
+            />
+          </dl>
+        </div>
+
+        <div className="mt-5 grid gap-5 border-t border-border-subtle pt-5 md:grid-cols-2">
+          <div>
+            <h3 className="mb-3 text-xs font-semibold text-ink-secondary">
+              Open age
+            </h3>
+            <Distribution
+              label="Active scanner findings by open-age bucket"
+              rows={openAgeRows}
+              total={movement.actionable}
+              colorClass="bg-amber-500"
+            />
+          </div>
+          <div>
+            <h3 className="mb-3 text-xs font-semibold text-ink-secondary">
+              Current severity
+            </h3>
+            <Distribution
+              label="Active scanner findings by current severity"
+              rows={severityRows}
+              total={movement.actionable}
+              colorClass="bg-red-500"
+            />
+            <p className="mt-3 text-[11px] leading-4 text-ink-tertiary">
+              Historical severity is unavailable until finding events carry
+              event-time snapshots.
+            </p>
+          </div>
+        </div>
+      </section>
+    </>
   );
 }
 

--- a/components/codebases/debt-dashboard.tsx
+++ b/components/codebases/debt-dashboard.tsx
@@ -243,7 +243,8 @@ export function ScannerCheckCoverage({
       ) : (
         <p className="mt-3 text-xs text-ink-secondary">
           Configured checks: Unknown · Complete required: Unknown · Findings
-          emitted: Unknown
+          emitted: Unknown · Legacy measured time:{" "}
+          {health?.measured_at ?? "Unknown"}
         </p>
       )}
     </section>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1839,3 +1839,9 @@ Freshness uses health measured_at with the existing fourteen-day threshold; stal
 error and partial cues coexist. V1/v2/absent census is unknown, measured zero is
 explicit, and required completeness never implies all-check completeness. Producer
 emission remains disabled until the separate production acceptance gate.
+
+The scanner conformance snapshot remains member API 1.25 even when newer intake
+contracts are published: `test/fixtures/contract/brain-contract.json` is vendored
+from Workspace's frozen `docs/contract/brain-contract-1.25.json`, with exact
+`codebase-payload-1.25` schema/fixture pins. This consumer does not claim the
+separate intake endpoint introduced by later member API revisions.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -400,7 +400,7 @@ unversioned `/api/brain/*` + `/api/dashboard/*` surfaces; `GET /api/v1/timeline`
 and `GET /api/v1/tasks` still discards its computed `truncated` (both need a brain-api bump, so they are
 deliberately not in this change).
 
-This server **implements brain-api v1.24** (the shipped member-facing wire contract; source of truth:
+This server **implements brain-api v1.25** (the shipped member-facing wire contract; source of truth:
 `aios-workspace/docs/brain-api.md`; see the v1.14 by-key lookup on
 `GET /api/v1/tasks` below; v1.8 added the subscriptions endpoint,
 `POST /api/v1/subscriptions`; the optional `context_health` object on `POST /api/v1/metrics`,
@@ -416,7 +416,7 @@ request-admission supplement** for `POST /api/v1/codebases` — canonical
 `aios-workspace/docs/contract/codebase-request-limits-v1.json`, vendored and sha256-pinned at
 `test/fixtures/contract/codebase-request-limits-v1.json`, carrying its own `revision: 1` and
 `appliesFromMemberApiVersion: "1.23"`. The effective contract is therefore *the published payload
-shape plus this admission supplement*, and the two move independently. `BRAIN_API_VERSION` is **1.24** with the scanner-identity implementation below; the admission
+shape plus this admission supplement*, and the two move independently. `BRAIN_API_VERSION` is **1.25** with the scanner-identity implementation below; the admission
 supplement remains independently versioned and does not itself bump the member API version. A limit is a **resource-admission** change, and the canonical change
 policy names that as an explicit exception to "breaking semantics go to /v2" — precedent: the 1.20
 `rows` cap and the dated 2026-06-19 same-route full-metrics tightening. (That exception and the
@@ -1823,3 +1823,19 @@ change neither weakens that check nor claims whole-ingest transaction atomicity.
 Before activation an old-function rollback preserves v2 operation. After activation,
 retain this compatible RPC or disable v3 emission before a reviewed rollback; never
 delete stored evidence or manually load production schema from a worktree.
+
+### Scanner check coverage (AIO-1096)
+
+The member API accepts the exact 1.25 health v3 census alongside unchanged v1/v2.
+The Zod boundary rejects unknown census keys, sibling sum failures, required-subset
+failures and inherited health/head contradictions before scan writes. Existing
+JSONB storage preserves the whole validated object; the same finding-ledger wrapper
+now admits v3 through the compatible RPC. No database migration is introduced.
+
+The codebase detail read model carries the typed last-scan health object into
+Scanner check coverage, below the UltraHarden gap and above scanner-admitted debt.
+It shows all/required configured and evidence counts, emitted findings and provenance.
+Freshness uses health measured_at with the existing fourteen-day threshold; stale,
+error and partial cues coexist. V1/v2/absent census is unknown, measured zero is
+explicit, and required completeness never implies all-check completeness. Producer
+emission remains disabled until the separate production acceptance gate.

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -354,7 +354,7 @@ chooses to adopt.
 ## 7. Upgrading across a brain-api contract bump
 
 The brain-api wire contract is versioned in **`aios-workspace/docs/brain-api.md`** (this server
-declares **v1.24** — `lib/api/version.ts`; this paragraph said v1.21 until 2026-08-25, which is the
+declares **v1.25** — `lib/api/version.ts`; this paragraph said v1.21 until 2026-08-25, which is the
 drift the table below exists to prevent and did not) — the single pinned contract both `aios-workspace` (the CLI/MCP client) and
 `aios-team-brain` (this server) build against. Per that doc's own change policy: a **breaking**
 change requires a **major version bump** (`/api/v2`); **additive** changes (new endpoints, new

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -66,7 +66,7 @@ const codebaseHealthV1Schema = z.strictObject({
     .string()
     .min(1)
     .max(20)
-    .refine((value) => value !== "2"),
+    .refine((value) => value !== "2" && value !== "3"),
   rubric_version: z.string().min(1).max(40),
   head_sha: z.string().regex(/^[0-9a-f]{7,40}$/),
   score_pct: z.number().min(0).max(100),
@@ -97,92 +97,153 @@ const evidenceStatusSchema = z.enum([
   "stale",
   "error",
 ]);
-const codebaseHealthV2Schema = z
-  .strictObject({
-    schema_version: z.literal("2"),
-    rubric_version: z.string().min(1).max(40),
-    profile_id: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/),
-    profile_version: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/),
-    head_sha: z.string().regex(/^[0-9a-f]{7,40}$/),
-    score_pct: z.number().min(0).max(100),
-    status: z.enum(["pass", "warn", "fail"]),
-    evidence_status: evidenceStatusSchema,
-    quality_gate: z.enum(["pass", "fail", "unknown"]),
-    automation_eligible: z.boolean(),
-    dimensions: z
-      .record(
-        z.string().regex(/^[a-z0-9][a-z0-9_-]{0,63}$/),
-        z.strictObject({
-          passed: z.number().int().nonnegative(),
-          total: z.number().int().nonnegative(),
-          band: z.number().int().min(0).max(4).nullable(),
-          evidence_status: evidenceStatusSchema,
-        }),
-      )
-      .refine((dimensions) => Object.keys(dimensions).length >= 1, {
-        message: "dimensions must have at least one entry",
+const codebaseHealthV2Base = z.strictObject({
+  schema_version: z.literal("2"),
+  rubric_version: z.string().min(1).max(40),
+  profile_id: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/),
+  profile_version: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/),
+  head_sha: z.string().regex(/^[0-9a-f]{7,40}$/),
+  score_pct: z.number().min(0).max(100),
+  status: z.enum(["pass", "warn", "fail"]),
+  evidence_status: evidenceStatusSchema,
+  quality_gate: z.enum(["pass", "fail", "unknown"]),
+  automation_eligible: z.boolean(),
+  dimensions: z
+    .record(
+      z.string().regex(/^[a-z0-9][a-z0-9_-]{0,63}$/),
+      z.strictObject({
+        passed: z.number().int().nonnegative(),
+        total: z.number().int().nonnegative(),
+        band: z.number().int().min(0).max(4).nullable(),
+        evidence_status: evidenceStatusSchema,
       }),
-    failed_invariant_ids: z
-      .array(z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/))
-      .max(200),
-    measured_at: z
-      .string()
-      .regex(
-        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/,
-      ),
-    findings: z
-      .array(
-        z.strictObject({
-          fingerprint: z.string().regex(/^[0-9a-f]{64}$/),
-          check_id: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/),
-          axis: z.string().regex(/^[a-z0-9][a-z0-9_-]{0,63}$/),
-          kind: z.enum(["quality_issue", "evidence_gap"]),
-          severity: z.enum(["low", "medium", "high", "critical"]),
-          evidence_status: evidenceStatusSchema,
-          remediation_tier: z.number().int().min(0).max(3),
-        }),
-      )
-      .max(500),
+    )
+    .refine((dimensions) => Object.keys(dimensions).length >= 1, {
+      message: "dimensions must have at least one entry",
+    }),
+  failed_invariant_ids: z
+    .array(z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/))
+    .max(200),
+  measured_at: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/),
+  findings: z
+    .array(
+      z.strictObject({
+        fingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+        check_id: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/),
+        axis: z.string().regex(/^[a-z0-9][a-z0-9_-]{0,63}$/),
+        kind: z.enum(["quality_issue", "evidence_gap"]),
+        severity: z.enum(["low", "medium", "high", "critical"]),
+        evidence_status: evidenceStatusSchema,
+        remediation_tier: z.number().int().min(0).max(3),
+      }),
+    )
+    .max(500),
+});
+
+function validateHealthEvidence(
+  health: Pick<
+    z.infer<typeof codebaseHealthV2Base>,
+    "quality_gate" | "evidence_status" | "automation_eligible" | "status"
+  >,
+  context: z.RefinementCtx,
+) {
+  if (health.quality_gate === "pass" && health.evidence_status !== "complete") {
+    context.addIssue({
+      code: "custom",
+      path: ["quality_gate"],
+      message: "a passing quality gate requires complete evidence",
+    });
+  }
+  if (
+    health.quality_gate === "unknown" &&
+    health.evidence_status === "complete"
+  ) {
+    context.addIssue({
+      code: "custom",
+      path: ["quality_gate"],
+      message: "an unknown quality gate cannot claim complete evidence",
+    });
+  }
+  if (
+    health.automation_eligible &&
+    (health.quality_gate !== "pass" ||
+      health.evidence_status !== "complete" ||
+      health.status === "fail")
+  ) {
+    context.addIssue({
+      code: "custom",
+      path: ["automation_eligible"],
+      message:
+        "automation requires complete evidence, a passing gate, and non-failing health",
+    });
+  }
+}
+
+const codebaseHealthV2Schema = codebaseHealthV2Base.superRefine(
+  validateHealthEvidence,
+);
+
+const checkCoverageBucket = z.strictObject({
+  configured: z.number().int().nonnegative(),
+  complete: z.number().int().nonnegative(),
+  partial: z.number().int().nonnegative(),
+  missing: z.number().int().nonnegative(),
+  stale: z.number().int().nonnegative(),
+  error: z.number().int().nonnegative(),
+});
+
+const codebaseHealthV3Schema = codebaseHealthV2Base
+  .extend({
+    schema_version: z.literal("3"),
+    check_coverage: z.strictObject({
+      all: checkCoverageBucket,
+      required: checkCoverageBucket,
+    }),
   })
+  .superRefine(validateHealthEvidence)
   .superRefine((health, context) => {
-    if (
-      health.quality_gate === "pass" &&
-      health.evidence_status !== "complete"
-    ) {
-      context.addIssue({
-        code: "custom",
-        path: ["quality_gate"],
-        message: "a passing quality gate requires complete evidence",
-      });
+    const coverage = health.check_coverage;
+    for (const name of ["all", "required"] as const) {
+      const bucket = coverage[name];
+      if (
+        bucket.configured !==
+        bucket.complete +
+          bucket.partial +
+          bucket.missing +
+          bucket.stale +
+          bucket.error
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["check_coverage", name, "configured"],
+          message: "configured must equal the sum of evidence states",
+        });
+      }
     }
-    if (
-      health.quality_gate === "unknown" &&
-      health.evidence_status === "complete"
-    ) {
-      context.addIssue({
-        code: "custom",
-        path: ["quality_gate"],
-        message: "an unknown quality gate cannot claim complete evidence",
-      });
-    }
-    if (
-      health.automation_eligible &&
-      (health.quality_gate !== "pass" ||
-        health.evidence_status !== "complete" ||
-        health.status === "fail")
-    ) {
-      context.addIssue({
-        code: "custom",
-        path: ["automation_eligible"],
-        message:
-          "automation requires complete evidence, a passing gate, and non-failing health",
-      });
+    for (const status of [
+      "configured",
+      "complete",
+      "partial",
+      "missing",
+      "stale",
+      "error",
+    ] as const) {
+      if (coverage.required[status] > coverage.all[status]) {
+        context.addIssue({
+          code: "custom",
+          path: ["check_coverage", "required", status],
+          message: "required checks must be a subset of all checks",
+        });
+      }
     }
   });
 
 // V1 remains accepted byte-for-byte. V2 adds the evidence needed to decide whether a
 // background remediation worker may act, without accepting raw source or finding text.
 export const codebaseHealthSchema = z.union([
+  codebaseHealthV3Schema,
   codebaseHealthV2Schema,
   codebaseHealthV1Schema,
 ]);
@@ -471,7 +532,7 @@ export const codebaseScanPayloadSchema = z
   .superRefine((payload, context) => {
     const health = payload.metrics.codebase_health;
     if (
-      health?.schema_version === "2" &&
+      (health?.schema_version === "2" || health?.schema_version === "3") &&
       health.head_sha !== payload.metrics.head_sha
     ) {
       context.addIssue({

--- a/lib/api/version.ts
+++ b/lib/api/version.ts
@@ -107,7 +107,8 @@
  *        NEEDS A MIGRATION: two new columns on `code_metrics`
  *        (postgres/migrations/20260831120000_code_metrics_scanner_identity.sql).
  */
-export const BRAIN_API_VERSION = "1.24";
+// 1.25 — closed health v3 configured-check census, persisted verbatim (AIO-1096).
+export const BRAIN_API_VERSION = "1.25";
 
 /** Server-only Executor gateway negotiation; independent of the member API surface. */
 export const GATEWAY_CONTRACT_VERSION = "1.10";

--- a/lib/codebases/finding-ledger.ts
+++ b/lib/codebases/finding-ledger.ts
@@ -76,15 +76,24 @@ export function decideFindingTransition(input: {
 
   if (olderThanCurrent) {
     if (currentStatus) {
-      return { status: currentStatus, event: "stale_analysis", mutatesCurrent: false };
+      return {
+        status: currentStatus,
+        event: "stale_analysis",
+        mutatesCurrent: false,
+      };
     }
     return present
-      ? { status: "stale_analysis", event: "stale_analysis", mutatesCurrent: false }
+      ? {
+          status: "stale_analysis",
+          event: "stale_analysis",
+          mutatesCurrent: false,
+        }
       : null;
   }
 
   if (present) {
-    if (!currentStatus) return { status: "open", event: "detected", mutatesCurrent: true };
+    if (!currentStatus)
+      return { status: "open", event: "detected", mutatesCurrent: true };
     if (currentStatus === "resolved" || currentStatus === "stale_analysis") {
       return { status: "reopened", event: "reopened", mutatesCurrent: true };
     }
@@ -118,7 +127,7 @@ const EMPTY_RESULT: FindingReconcileResult = {
   stale: 0,
 };
 
-/** Atomically project one validated v2 snapshot into current state + append-only history. */
+/** Atomically project one validated v2/v3 snapshot into current state + append-only history. */
 export async function reconcileCodebaseFindings(
   db: DbClient,
   input: {
@@ -126,9 +135,13 @@ export async function reconcileCodebaseFindings(
     codebaseId: string;
     metricsId: string;
     health: CodebaseHealth | undefined;
-  }
+  },
 ): Promise<FindingReconcileResult> {
-  if (!input.health || input.health.schema_version !== "2") return EMPTY_RESULT;
+  if (
+    !input.health ||
+    (input.health.schema_version !== "2" && input.health.schema_version !== "3")
+  )
+    return EMPTY_RESULT;
 
   const { data, error } = await db.rpc("reconcile_codebase_findings", {
     p_team_id: input.teamId,
@@ -147,7 +160,7 @@ export async function decideCodebaseFinding(
     teamId: string;
     codebaseId: string;
     actorMemberId: string;
-  }
+  },
 ): Promise<{ findingId: string; status: FindingDecision["status"] }> {
   const decision = findingDecisionSchema.parse(input);
   const { data, error } = await db.rpc("decide_codebase_finding", {

--- a/lib/codebases/ingest.ts
+++ b/lib/codebases/ingest.ts
@@ -4,7 +4,10 @@ import type { CodebaseScanPayload } from "@/lib/api/schemas";
 import { computeScores } from "@/lib/codebases/score";
 import { normalizeStoredScannerField } from "@/lib/codebases/scanner-version";
 import { buildIdentityMap, resolveMember } from "@/lib/identity/resolve";
-import { projectCommitsToItems, type ScanCommit } from "@/lib/codebases/commits-to-items";
+import {
+  projectCommitsToItems,
+  type ScanCommit,
+} from "@/lib/codebases/commits-to-items";
 import { audit } from "@/lib/api/audit";
 import { reconcileCodebaseFindings } from "@/lib/codebases/finding-ledger";
 
@@ -21,8 +24,13 @@ import { reconcileCodebaseFindings } from "@/lib/codebases/finding-ledger";
 export async function ingestCodebaseScan(
   db: DbClient,
   auth: { teamId: string; memberId: string; apiKeyId: string },
-  payload: CodebaseScanPayload
-): Promise<{ codebase_id: string; metrics_id: string; contributions: number; issues: number }> {
+  payload: CodebaseScanPayload,
+): Promise<{
+  codebase_id: string;
+  metrics_id: string;
+  contributions: number;
+  issues: number;
+}> {
   const now = new Date().toISOString();
   const c = payload.codebase;
 
@@ -46,11 +54,12 @@ export async function ingestCodebaseScan(
         is_archived: c.is_archived,
         last_scan_at: now,
       },
-      { onConflict: "team_id,slug" }
+      { onConflict: "team_id,slug" },
     )
     .select("id")
     .single();
-  if (cbErr || !codebase) throw new Error(`codebase upsert failed: ${cbErr?.message}`);
+  if (cbErr || !codebase)
+    throw new Error(`codebase upsert failed: ${cbErr?.message}`);
 
   // 2. compute scores from raw metrics
   const m = payload.metrics;
@@ -136,13 +145,14 @@ export async function ingestCodebaseScan(
         scanner_sha: normalizeStoredScannerField(m.scanner_sha),
         ...scores,
       },
-      { onConflict: "codebase_id,head_sha" }
+      { onConflict: "codebase_id,head_sha" },
     )
     .select("id")
     .single();
-  if (mErr || !metrics) throw new Error(`code_metrics upsert failed: ${mErr?.message}`);
+  if (mErr || !metrics)
+    throw new Error(`code_metrics upsert failed: ${mErr?.message}`);
 
-  // 4. project validated v2 findings into durable current state + append-only history.
+  // 4. project validated v2/v3 findings into durable current state + append-only history.
   // Historical v1/v1.0 snapshots remain metrics-only. The DB function is atomic and
   // idempotent for the same metrics point; incomplete evidence can never resolve absence.
   const findingLedger = await reconcileCodebaseFindings(db, {
@@ -178,15 +188,24 @@ export async function ingestCodebaseScan(
           additions: row.additions,
           deletions: row.deletions,
         },
-        { onConflict: "codebase_id,author_key,day" }
+        { onConflict: "codebase_id,author_key,day" },
       );
-      if (error) throw new Error(`contribution ${row.author_key}/${row.day}: ${error.message}`);
+      if (error)
+        throw new Error(
+          `contribution ${row.author_key}/${row.day}: ${error.message}`,
+        );
       contribCount++;
     }
 
     // Project recent commits into searchable items (author message text + member attribution),
     // so NL queries can answer per-person git history — not just the aggregate counts above.
-    commitItemCount = await projectCommitsToItems(db, auth, c.slug, recentCommits, identityMap);
+    commitItemCount = await projectCommitsToItems(
+      db,
+      auth,
+      c.slug,
+      recentCommits,
+      identityMap,
+    );
   }
 
   // 6. issues — upsert by number
@@ -209,7 +228,7 @@ export async function ingestCodebaseScan(
         closed_at: iss.closed_at || null,
         updated_at: now,
       },
-      { onConflict: "codebase_id,number" }
+      { onConflict: "codebase_id,number" },
     );
     if (error) throw new Error(`issue #${iss.number}: ${error.message}`);
     issueCount++;

--- a/lib/metrics/codebases.ts
+++ b/lib/metrics/codebases.ts
@@ -461,7 +461,7 @@ export interface AgenticBreakdown {
   readiness_level: string | null;
   readiness_pct: number | null;
   readiness_pillars: Record<string, { passed: number; total: number }>;
-  // Workspace-governance health (brain-api 1.15) — the LAST scan's snapshot, verbatim as
+  // Workspace-governance health (brain-api 1.25, v1/v2/v3 union) — the LAST scan's snapshot, verbatim as
   // pushed (incl. measured_at); null = that scan carried no health object. Provenance-only.
   codebase_health: CodebaseHealth | null;
 }

--- a/test/datamechanics/codebase-health-v3-rpc.datamechanics.test.ts
+++ b/test/datamechanics/codebase-health-v3-rpc.datamechanics.test.ts
@@ -105,7 +105,7 @@ async function snapshot() {
 describe("health v3 SQL compatibility", () => {
   it("uses exact canonical 1.25 fixture bytes", () => {
     expect(createHash("sha256").update(fixtureBytes).digest("hex")).toBe(
-      "22bc99241032d38578be67a3130af08404efe4588cf678046fb687a00ab91d5a",
+      "d053f4aa12e9afb5d4b8c7a636f399b177ba51f1871f9c2472cab713b4f76b7e",
     );
     expect(canonical.schema_version).toBe("3");
   });

--- a/test/datamechanics/codebase-health.datamechanics.test.ts
+++ b/test/datamechanics/codebase-health.datamechanics.test.ts
@@ -698,6 +698,10 @@ describe("health v3 route and census persistence", () => {
       post(key, seed.teamSlug, first),
       post(key, seed.teamSlug, second),
     ]);
+    console.info(
+      "AIO-1096 concurrent same-head HTTP outcomes",
+      responses.map((r) => r.status),
+    );
     expect(responses.some((r) => r.status === 201)).toBe(true);
     for (const response of responses) {
       if (response.status !== 201) {

--- a/test/datamechanics/codebase-health.datamechanics.test.ts
+++ b/test/datamechanics/codebase-health.datamechanics.test.ts
@@ -698,9 +698,8 @@ describe("health v3 route and census persistence", () => {
       post(key, seed.teamSlug, first),
       post(key, seed.teamSlug, second),
     ]);
-    console.info(
-      "AIO-1096 concurrent same-head HTTP outcomes",
-      responses.map((r) => r.status),
+    process.stdout.write(
+      `Concurrent same-head HTTP outcomes: ${JSON.stringify(responses.map((r) => r.status))}\n`,
     );
     expect(responses.some((r) => r.status === 201)).toBe(true);
     for (const response of responses) {

--- a/test/datamechanics/codebase-health.datamechanics.test.ts
+++ b/test/datamechanics/codebase-health.datamechanics.test.ts
@@ -5,7 +5,10 @@ import { randomUUID } from "node:crypto";
 import type { NextRequest } from "next/server";
 import { POST as codebasesPOST } from "@/app/api/v1/codebases/route";
 import { issueApiKey } from "@/lib/admin/keys";
-import { getCodebaseDetail, getCodebaseSummaries } from "@/lib/metrics/codebases";
+import {
+  getCodebaseDetail,
+  getCodebaseSummaries,
+} from "@/lib/metrics/codebases";
 import { db, seedTeam, type Seed } from "./helpers";
 
 // Spec (brain-api document revision 1.15, AIO-609): POST /api/v1/codebases accepts an
@@ -17,15 +20,27 @@ import { db, seedTeam, type Seed } from "./helpers";
 
 const CB_URL = "http://test/api/v1/codebases";
 
-type Fixture = { name: string; payload: { codebase: { slug: string }; metrics: Record<string, unknown> } };
+type Fixture = {
+  name: string;
+  payload: { codebase: { slug: string }; metrics: Record<string, unknown> };
+};
 const fixtures = JSON.parse(
   readFileSync(
-    join(import.meta.dirname, "..", "fixtures", "contract", "codebase-payload-1.22-fixtures.json"),
+    join(
+      import.meta.dirname,
+      "..",
+      "fixtures",
+      "contract",
+      "codebase-payload-1.22-fixtures.json",
+    ),
     "utf8",
   ),
 ) as { valid: Fixture[]; invalid: Fixture[] };
 
-function fixture(bucket: "valid" | "invalid", prefix: string): Fixture["payload"] {
+function fixture(
+  bucket: "valid" | "invalid",
+  prefix: string,
+): Fixture["payload"] {
   const f = fixtures[bucket].find((x) => x.name.startsWith(prefix));
   if (!f) throw new Error(`fixture ${bucket}/${prefix} missing`);
   // Deep-copy so per-test slug overrides never leak between tests.
@@ -65,7 +80,11 @@ function v2Payload(input: {
     score_pct: complete && findings.length === 0 ? 100 : 70,
     status: complete ? (findings.length === 0 ? "pass" : "fail") : "warn",
     evidence_status: evidenceStatus,
-    quality_gate: complete ? (findings.length === 0 ? "pass" : "fail") : "unknown",
+    quality_gate: complete
+      ? findings.length === 0
+        ? "pass"
+        : "fail"
+      : "unknown",
     automation_eligible: complete && findings.length === 0,
     dimensions: {
       test_rigor: {
@@ -109,7 +128,8 @@ async function issueKeyFor(seed: Seed, tier: "team" | "external") {
       })
       .select("id")
       .single();
-    if (error || !data) throw new Error(`external member seed failed: ${error?.message}`);
+    if (error || !data)
+      throw new Error(`external member seed failed: ${error?.message}`);
     memberId = (data as { id: string }).id;
   }
   const { key } = await issueApiKey(db(), seed.teamId, memberId, `${tier} key`);
@@ -140,10 +160,20 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
     const res = await post(key, seed.teamSlug, body);
     expect(res.status).toBe(201);
 
-    const detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    const detail = await getCodebaseDetail(
+      db(),
+      seed.teamId,
+      slug,
+      "90d",
+      "team",
+    );
     // Verbatim: the exact object the scanner pushed, incl. measured_at — no recompute.
-    expect(detail?.breakdown?.codebase_health).toEqual(body.metrics.codebase_health);
-    expect(detail?.breakdown?.codebase_health?.measured_at).toBe("2026-07-30T09:00:00Z");
+    expect(detail?.breakdown?.codebase_health).toEqual(
+      body.metrics.codebase_health,
+    );
+    expect(detail?.breakdown?.codebase_health?.measured_at).toBe(
+      "2026-07-30T09:00:00Z",
+    );
     expect(detail?.breakdown?.codebase_health?.status).toBe("warn");
   });
 
@@ -157,7 +187,13 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
     const res = await post(key, seed.teamSlug, body);
     expect(res.status).toBe(201);
 
-    const detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    const detail = await getCodebaseDetail(
+      db(),
+      seed.teamId,
+      slug,
+      "90d",
+      "team",
+    );
     expect(detail?.breakdown).not.toBeNull();
     expect(detail?.breakdown?.codebase_health).toBeNull();
     expect(detail?.findings).toEqual([]);
@@ -175,18 +211,30 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
     });
 
     expect((await post(key, seed.teamSlug, first)).status).toBe(201);
-    let detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
-    expect(detail?.breakdown?.codebase_health).toEqual(first.metrics.codebase_health);
+    let detail = await getCodebaseDetail(
+      db(),
+      seed.teamId,
+      slug,
+      "90d",
+      "team",
+    );
+    expect(detail?.breakdown?.codebase_health).toEqual(
+      first.metrics.codebase_health,
+    );
     expect(detail?.findings).toHaveLength(1);
     expect(detail?.findings[0]).toMatchObject({
       fingerprint: FINDING_A.fingerprint,
       status: "open",
       occurrence_count: 1,
     });
-    expect(detail?.findings[0].events.map((event) => event.event_type)).toEqual(["detected"]);
+    expect(detail?.findings[0].events.map((event) => event.event_type)).toEqual(
+      ["detected"],
+    );
 
     // Same exact metrics point is idempotent: no duplicate row and no duplicate event.
-    expect((await post(key, seed.teamSlug, structuredClone(first))).status).toBe(201);
+    expect(
+      (await post(key, seed.teamSlug, structuredClone(first))).status,
+    ).toBe(201);
     detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
     expect(detail?.findings[0].events).toHaveLength(1);
 
@@ -217,9 +265,14 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
       measuredAt: "2026-08-04T02:30:00Z",
       findings: [FINDING_A],
     });
-    expect((await post(key, seed.teamSlug, staleBeforeReopen)).status).toBe(201);
+    expect((await post(key, seed.teamSlug, staleBeforeReopen)).status).toBe(
+      201,
+    );
     detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
-    expect(detail?.findings[0]).toMatchObject({ status: "resolved", occurrence_count: 1 });
+    expect(detail?.findings[0]).toMatchObject({
+      status: "resolved",
+      occurrence_count: 1,
+    });
 
     const reopened = v2Payload({
       slug,
@@ -230,13 +283,13 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
     expect((await post(key, seed.teamSlug, reopened)).status).toBe(201);
 
     detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
-    expect(detail?.findings[0]).toMatchObject({ status: "reopened", occurrence_count: 2 });
-    expect(detail?.findings[0].events.map((event) => event.event_type).sort()).toEqual([
-      "detected",
-      "reopened",
-      "resolved",
-      "stale_analysis",
-    ]);
+    expect(detail?.findings[0]).toMatchObject({
+      status: "reopened",
+      occurrence_count: 2,
+    });
+    expect(
+      detail?.findings[0].events.map((event) => event.event_type).sort(),
+    ).toEqual(["detected", "reopened", "resolved", "stale_analysis"]);
 
     // An older analysis is history only; it cannot overwrite the reopened current state.
     const stale = v2Payload({
@@ -252,9 +305,11 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
       last_seen_sha: "4".repeat(40),
       occurrence_count: 2,
     });
-    expect(detail?.findings[0].events.some((event) => event.event_type === "stale_analysis")).toBe(
-      true
-    );
+    expect(
+      detail?.findings[0].events.some(
+        (event) => event.event_type === "stale_analysis",
+      ),
+    ).toBe(true);
   });
 
   it("v2 ledger rows remain isolated between teams for the same repository slug", async () => {
@@ -263,7 +318,11 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
     const oneKey = await issueKeyFor(one, "team");
     const twoKey = await issueKeyFor(two, "team");
     const slug = `shared-${randomUUID().slice(0, 6)}`;
-    const findingB = { ...FINDING_A, fingerprint: "b".repeat(64), check_id: "eslint_warning_count" };
+    const findingB = {
+      ...FINDING_A,
+      fingerprint: "b".repeat(64),
+      check_id: "eslint_warning_count",
+    };
 
     expect(
       (
@@ -275,9 +334,9 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
             head: "6".repeat(40),
             measuredAt: "2026-08-04T05:00:00Z",
             findings: [FINDING_A],
-          })
+          }),
         )
-      ).status
+      ).status,
     ).toBe(201);
     expect(
       (
@@ -289,13 +348,25 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
             head: "7".repeat(40),
             measuredAt: "2026-08-04T05:00:00Z",
             findings: [findingB],
-          })
+          }),
         )
-      ).status
+      ).status,
     ).toBe(201);
 
-    const oneDetail = await getCodebaseDetail(db(), one.teamId, slug, "90d", "team");
-    const twoDetail = await getCodebaseDetail(db(), two.teamId, slug, "90d", "team");
+    const oneDetail = await getCodebaseDetail(
+      db(),
+      one.teamId,
+      slug,
+      "90d",
+      "team",
+    );
+    const twoDetail = await getCodebaseDetail(
+      db(),
+      two.teamId,
+      slug,
+      "90d",
+      "team",
+    );
     expect(oneDetail?.findings.map((finding) => finding.fingerprint)).toEqual([
       FINDING_A.fingerprint,
     ]);
@@ -323,16 +394,22 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
     });
     expect((await post(key, seed.teamSlug, olderDirty)).status).toBe(201);
 
-    const detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    const detail = await getCodebaseDetail(
+      db(),
+      seed.teamId,
+      slug,
+      "90d",
+      "team",
+    );
     expect(detail?.findings).toHaveLength(1);
     expect(detail?.findings[0]).toMatchObject({
       fingerprint: FINDING_A.fingerprint,
       status: "stale_analysis",
       occurrence_count: 1,
     });
-    expect(detail?.findings[0].events.map((event) => event.event_type)).toEqual([
-      "stale_analysis",
-    ]);
+    expect(detail?.findings[0].events.map((event) => event.event_type)).toEqual(
+      ["stale_analysis"],
+    );
   });
 
   it("422 sparse: health without the full raw-metrics block is rejected, nothing persisted", async () => {
@@ -347,7 +424,13 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
     expect((await res.json()).error.code).toBe("invalid_payload");
 
     // Rejected at the boundary — no codebase/metrics row was upserted for the slug.
-    const detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
+    const detail = await getCodebaseDetail(
+      db(),
+      seed.teamId,
+      slug,
+      "90d",
+      "team",
+    );
     expect(detail).toBeNull();
   });
 
@@ -371,12 +454,15 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
       measuredAt: "2026-08-04T06:00:00Z",
       findings: [FINDING_A],
     });
-    (body.metrics.codebase_health as { head_sha: string }).head_sha = "9".repeat(40);
+    (body.metrics.codebase_health as { head_sha: string }).head_sha =
+      "9".repeat(40);
 
     const res = await post(key, seed.teamSlug, body);
     expect(res.status).toBe(422);
     expect((await res.json()).error.code).toBe("invalid_payload");
-    expect(await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team")).toBeNull();
+    expect(
+      await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team"),
+    ).toBeNull();
   });
 
   it("422 smuggled key: a health object carrying a file path is rejected, not stripped", async () => {
@@ -423,8 +509,16 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
     expect(rows).toHaveLength(1);
     expect((rows as { id: string }[])[0].id).toBe(metrics_id);
 
-    const detail = await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team");
-    expect(detail?.breakdown?.codebase_health).toEqual(body.metrics.codebase_health);
+    const detail = await getCodebaseDetail(
+      db(),
+      seed.teamId,
+      slug,
+      "90d",
+      "team",
+    );
+    expect(detail?.breakdown?.codebase_health).toEqual(
+      body.metrics.codebase_health,
+    );
   });
 
   it("health is team-tier only on the read side — external viewers get nothing", async () => {
@@ -435,8 +529,281 @@ describe("codebase_health ingest (real route handler, real Postgres)", () => {
     body.codebase.slug = slug;
     expect((await post(key, seed.teamSlug, body)).status).toBe(201);
 
-    const { codebases } = await getCodebaseSummaries(db(), seed.teamId, "90d", "external");
+    const { codebases } = await getCodebaseSummaries(
+      db(),
+      seed.teamId,
+      "90d",
+      "external",
+    );
     expect(codebases).toHaveLength(0);
-    expect(await getCodebaseDetail(db(), seed.teamId, slug, "90d", "external")).toBeNull();
+    expect(
+      await getCodebaseDetail(db(), seed.teamId, slug, "90d", "external"),
+    ).toBeNull();
+  });
+});
+
+// AIO-1096: real route + existing writer/read model, exact canonical 1.25 payloads.
+const coverageFixtures = JSON.parse(
+  readFileSync(
+    join(
+      import.meta.dirname,
+      "..",
+      "fixtures",
+      "contract",
+      "codebase-payload-1.25-fixtures.json",
+    ),
+    "utf8",
+  ),
+) as {
+  valid: Fixture[];
+  coverage_invalid: Fixture[];
+};
+function coveragePayload(name = "valid-v3-complete") {
+  const value = coverageFixtures.valid.find((f) => f.name === name);
+  if (!value) throw new Error(`missing canonical ${name}`);
+  const payload = structuredClone(value.payload);
+  // Test scenario targets the health measurement's commit. Upstream artifact bytes
+  // remain separately hash-pinned and checked by the canonical conformance guard.
+  payload.metrics.head_sha = (
+    payload.metrics.codebase_health as { head_sha: string }
+  ).head_sha;
+  return payload;
+}
+async function scanDomainState() {
+  const tables = [
+    "codebases",
+    "code_metrics",
+    "codebase_findings",
+    "codebase_finding_events",
+    "code_contributions",
+    "github_issues",
+    "audit_log",
+    "ingest_runs",
+  ];
+  const state: Record<string, unknown> = {};
+  for (const table of tables) {
+    const result = await db().from(table).select("*").order("id");
+    expect(result.error, table).toBeNull();
+    state[table] = result.data;
+  }
+  return state;
+}
+
+describe("health v3 route and census persistence", () => {
+  it("round-trips canonical v3 through JSONB and detail without replacing legacy unknowns", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+    const body = coveragePayload();
+    body.codebase.slug = `v3-${randomUUID().slice(0, 8)}`;
+    const first = await post(key, seed.teamSlug, body);
+    expect(first.status).toBe(201);
+    const ids = await first.json();
+    expect((await post(key, seed.teamSlug, body)).status).toBe(201);
+    const { data: rows } = await db()
+      .from("code_metrics")
+      .select("id,codebase_health")
+      .eq("codebase_id", ids.codebase_id);
+    expect(rows).toEqual([
+      { id: ids.metrics_id, codebase_health: body.metrics.codebase_health },
+    ]);
+    const detail = await getCodebaseDetail(
+      db(),
+      seed.teamId,
+      body.codebase.slug,
+      "90d",
+      "team",
+    );
+    expect(detail?.breakdown?.codebase_health).toEqual(
+      body.metrics.codebase_health,
+    );
+    expect(
+      await getCodebaseDetail(
+        db(),
+        seed.teamId,
+        body.codebase.slug,
+        "90d",
+        "external",
+      ),
+    ).toBeNull();
+    for (const prefix of ["valid-without-health", "valid-with-health"]) {
+      const old = fixture("valid", prefix);
+      old.codebase.slug = `legacy-${randomUUID().slice(0, 8)}`;
+      expect((await post(key, seed.teamSlug, old)).status).toBe(201);
+      const oldDetail = await getCodebaseDetail(
+        db(),
+        seed.teamId,
+        old.codebase.slug,
+        "90d",
+        "team",
+      );
+      expect(oldDetail?.breakdown?.codebase_health).toEqual(
+        old.metrics.codebase_health ?? null,
+      );
+      expect(oldDetail?.breakdown?.codebase_health ?? {}).not.toHaveProperty(
+        "check_coverage",
+      );
+    }
+  });
+
+  it.each(
+    coverageFixtures.coverage_invalid.map((f) => [f.name, f.payload] as const),
+  )("422 %s leaves all scan-domain state unchanged", async (_name, invalid) => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+    const valid = coveragePayload();
+    valid.codebase.slug = `invalid-${randomUUID().slice(0, 8)}`;
+    expect((await post(key, seed.teamSlug, valid)).status).toBe(201);
+    const before = await scanDomainState();
+    const body = structuredClone(invalid);
+    body.codebase.slug = valid.codebase.slug;
+    body.metrics.head_sha = (
+      body.metrics.codebase_health as { head_sha: string }
+    ).head_sha;
+    const response = await post(key, seed.teamSlug, body);
+    expect(response.status).toBe(422);
+    expect((await response.json()).error.code).toBe("invalid_payload");
+    expect(await scanDomainState()).toEqual(before);
+  });
+
+  it("concurrent differing same-head submissions preserve one whole submitted snapshot", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+    const first = coveragePayload();
+    first.codebase.slug = `race-${randomUUID().slice(0, 8)}`;
+    const second = structuredClone(first);
+    const secondHealth = second.metrics.codebase_health as Record<
+      string,
+      unknown
+    >;
+    secondHealth.profile_id = "second-snapshot";
+    secondHealth.check_coverage = {
+      all: {
+        configured: 9,
+        complete: 9,
+        partial: 0,
+        missing: 0,
+        stale: 0,
+        error: 0,
+      },
+      required: {
+        configured: 3,
+        complete: 3,
+        partial: 0,
+        missing: 0,
+        stale: 0,
+        error: 0,
+      },
+    };
+    const responses = await Promise.all([
+      post(key, seed.teamSlug, first),
+      post(key, seed.teamSlug, second),
+    ]);
+    expect(responses.some((r) => r.status === 201)).toBe(true);
+    for (const response of responses) {
+      if (response.status !== 201) {
+        expect(response.status).toBe(500);
+        expect((await response.json()).error.message).toContain(
+          "metrics identity mismatch",
+        );
+      }
+    }
+    const detail = await getCodebaseDetail(
+      db(),
+      seed.teamId,
+      first.codebase.slug,
+      "90d",
+      "team",
+    );
+    expect([
+      first.metrics.codebase_health,
+      second.metrics.codebase_health,
+    ]).toContainEqual(detail?.breakdown?.codebase_health);
+    const result = await db()
+      .from("code_metrics")
+      .select("codebase_health")
+      .eq("codebase_id", detail!.id);
+    expect(result.data).toHaveLength(1);
+    expect(result.data![0].codebase_health).toEqual(
+      detail?.breakdown?.codebase_health,
+    );
+  });
+
+  it("v3 stays team isolated and keeps 401/403 precedence", async () => {
+    const one = await seedTeam();
+    const two = await seedTeam();
+    const oneKey = await issueKeyFor(one, "team");
+    const twoKey = await issueKeyFor(two, "team");
+    const body = coveragePayload();
+    body.codebase.slug = "same-v3-slug";
+    const other = coveragePayload("valid-v3-zero");
+    other.codebase.slug = body.codebase.slug;
+    expect((await post(oneKey.key, one.teamSlug, body)).status).toBe(201);
+    expect((await post(twoKey.key, two.teamSlug, other)).status).toBe(201);
+    expect(
+      (
+        await getCodebaseDetail(
+          db(),
+          one.teamId,
+          body.codebase.slug,
+          "90d",
+          "team",
+        )
+      )?.breakdown?.codebase_health,
+    ).toEqual(body.metrics.codebase_health);
+    expect(
+      (
+        await getCodebaseDetail(
+          db(),
+          two.teamId,
+          body.codebase.slug,
+          "90d",
+          "team",
+        )
+      )?.breakdown?.codebase_health,
+    ).toEqual(other.metrics.codebase_health);
+    const external = await issueKeyFor(one, "external");
+    const denied = await post(external.key, one.teamSlug, body);
+    expect(denied.status).toBe(403);
+    expect((await denied.json()).error.code).toBe("forbidden_tier");
+    expect((await post("", one.teamSlug, body)).status).toBe(401);
+  });
+
+  it("v3 route keeps the existing finding lifecycle and mixed-version ordering", async () => {
+    const seed = await seedTeam();
+    const { key } = await issueKeyFor(seed, "team");
+    const slug = `v3-ledger-${randomUUID().slice(0, 8)}`;
+    const first = coveragePayload();
+    first.codebase.slug = slug;
+    const firstHealth = first.metrics.codebase_health as Record<
+      string,
+      unknown
+    >;
+    firstHealth.findings = [FINDING_A];
+    expect((await post(key, seed.teamSlug, first)).status).toBe(201);
+    expect(
+      (await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team"))
+        ?.findings[0].status,
+    ).toBe("open");
+    const newerV2 = v2Payload({
+      slug,
+      head: "d".repeat(40),
+      measuredAt: "2026-09-01T01:00:00Z",
+    });
+    expect((await post(key, seed.teamSlug, newerV2)).status).toBe(201);
+    expect(
+      (await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team"))
+        ?.findings[0].status,
+    ).toBe("resolved");
+    const newerV3 = structuredClone(first);
+    newerV3.metrics.head_sha = "e".repeat(40);
+    Object.assign(newerV3.metrics.codebase_health as object, {
+      head_sha: "e".repeat(40),
+      measured_at: "2026-09-01T02:00:00Z",
+    });
+    expect((await post(key, seed.teamSlug, newerV3)).status).toBe(201);
+    expect(
+      (await getCodebaseDetail(db(), seed.teamId, slug, "90d", "team"))
+        ?.findings[0].status,
+    ).toBe("reopened");
   });
 });

--- a/test/fixtures/contract/brain-contract.json
+++ b/test/fixtures/contract/brain-contract.json
@@ -109,8 +109,8 @@
     },
     "fixtures": {
       "path": "codebase-payload-1.25-fixtures.json",
-      "sha256": "22bc99241032d38578be67a3130af08404efe4588cf678046fb687a00ab91d5a"
+      "sha256": "d053f4aa12e9afb5d4b8c7a636f399b177ba51f1871f9c2472cab713b4f76b7e"
     }
   },
-  "contentHash": "f46873c773f759512966a1e0f7b8d2efbdb0797a99d184d83bc9b2f23005040b"
+  "contentHash": "e9d81bb9873d09e2f15964f1f99cf6108eba862a411999dea1a2a08310c16e1e"
 }

--- a/test/fixtures/contract/brain-contract.json
+++ b/test/fixtures/contract/brain-contract.json
@@ -1,7 +1,7 @@
 {
   "$schema": "aios-brain-contract/v1",
   "_note": "Canonical conformance fixture for the workspace<->brain seam (AIO-314). Home: aios-workspace/docs/contract. Vendored into aios-team-brain/test/fixtures/contract. contentHash pins the content; /docs-sync compares the two copies. Regenerate: node scripts/gen-contract-fixture.mjs.",
-  "version": "1.24",
+  "version": "1.25",
   "tierAliases": {
     "shared": {
       "team": "team",
@@ -100,17 +100,17 @@
     }
   },
   "codebasePayloadContract": {
-    "version": "1.24",
+    "version": "1.25",
     "minScannerVersion": "0.2.0",
     "_minScannerVersionNote": "The oldest ingestion-package build (aios_ingest.__version__) that emits everything this contract revision asks a scanner for. A scan whose metrics.scanner_version is PARSEABLE and orders below this is STALE. Absent, null or unparseable is UNKNOWN, which is a DIFFERENT outcome and must never be reported as stale: 'the scan did not tell us' is not 'the scan told us it is old', and collapsing the two is the exact error this field exists to remove. Three states, no fourth: unknown | stale | current (see the truth table in docs/brain-api.md, and the scanner_state conformance vectors in codebase-payload-1.24-fixtures.json). PARSEABLE is narrow and normative: exactly three dotted non-negative integers, nothing else, so a leading v, a two-part version, a channel name and any SemVer pre-release or build suffix are UNREADABLE and therefore unknown - a pre-release sorts before its release and is not evidence the build emits what the release promises. Note too that unknown is NOT a synonym for 'predates 1.24': a current scanner that cannot determine its own build is required to send null rather than guess. Either way the brain says so at the point of confusion rather than rendering an unexplained '(scope unknown)'. Deliberately a declared minimum and NOT a commit distance: commit distance is undefined across branches and forks, needs a git history the brain does not hold at runtime, stops existing when the scanner ships as a package, and says nothing about whether anything the contract needs actually changed. The cost of the choice, stated so it is not forgotten: RAISE THIS in the same PR as any revision that requires new scanner output, or staleness detection is silently off for that field. The brain mirrors this value in lib/codebases/scanner-version.ts and a guard asserts the two agree.",
     "schema": {
-      "path": "codebase-payload-1.24.schema.json",
-      "sha256": "761f8e74be2f98d2883d9d61697f7d0c95c28df7770ba7e467d35dd6492feca6"
+      "path": "codebase-payload-1.25.schema.json",
+      "sha256": "79cd93c4b46b7ded3af73ac0e320498036bc1e39d7677cad18a6554b1d620d66"
     },
     "fixtures": {
-      "path": "codebase-payload-1.24-fixtures.json",
-      "sha256": "67fa64a19273c0ec78f571a9f956de19fb5174febdb1ba081c4e651fa024b7fd"
+      "path": "codebase-payload-1.25-fixtures.json",
+      "sha256": "22bc99241032d38578be67a3130af08404efe4588cf678046fb687a00ab91d5a"
     }
   },
-  "contentHash": "2b02a74f6ef036170d63425265dce88ba8c71e35573c5810cca5fe592f1976f2"
+  "contentHash": "f46873c773f759512966a1e0f7b8d2efbdb0797a99d184d83bc9b2f23005040b"
 }

--- a/test/fixtures/contract/codebase-payload-1.25-fixtures.json
+++ b/test/fixtures/contract/codebase-payload-1.25-fixtures.json
@@ -716,7 +716,7 @@
           "codebase_health": {
             "schema_version": "2",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -804,7 +804,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -910,7 +910,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -1016,7 +1016,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -1122,7 +1122,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -13534,7 +13534,7 @@
         "state": "unknown"
       },
       {
-        "name": "empty string: unreadable, so unknown — and still not a 422",
+        "name": "empty string: unreadable, so unknown \u2014 and still not a 422",
         "scanner_version": "",
         "state": "unknown"
       },
@@ -13676,7 +13676,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -13782,7 +13782,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -13888,7 +13888,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -13994,7 +13994,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -14100,7 +14100,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -14206,7 +14206,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -14312,7 +14312,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -14418,7 +14418,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -14524,7 +14524,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -14630,7 +14630,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -14736,7 +14736,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -14842,7 +14842,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -14948,7 +14948,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {
@@ -15054,7 +15054,7 @@
           "codebase_health": {
             "schema_version": "3",
             "rubric_version": "1.0.0",
-            "head_sha": "ffff0000ffff0000ffff0000ffff0000ffff0000",
+            "head_sha": "abc123def456abc123def456abc123def456abc1",
             "score_pct": 100,
             "status": "pass",
             "dimensions": {

--- a/test/fixtures/contract/codebase-payload-1.25.schema.json
+++ b/test/fixtures/contract/codebase-payload-1.25.schema.json
@@ -1,0 +1,1050 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aios.dev/contracts/brain-api/1.25/codebase-payload.schema.json",
+  "title": "AIOS Brain API 1.25 codebase scan payload (POST /api/v1/codebases)",
+  "description": "Machine-readable contract for POST /api/v1/codebases. Revision 1.24 adds the two optional scanner-identity fields - `metrics.scanner_version` and `metrics.scanner_sha` (AIO-1011) - on top of the 1.23 commit-classification / fix-analysis contract and the 1.22 coverage denominator. Strictness is deliberately scoped: codebase_health plus the two analytical commit objects are closed; the surrounding codebase, metrics, and recent-commit shapes stay open for additive scanner fields. The full raw-metrics block remains required because its upsert replaces the row on (codebase_id, head_sha). JSON Schema 2020-12 cannot compare sibling sums, so coverage and fix-analysis numeric coherence rules are normative in docs/brain-api.md and enforced by the brain boundary. SECOND LIMIT, new at 1.24 and deliberate: the scanner-identity fields are typed loosely (string or null, bounded length) and carry NO `pattern`. Their SHAPE is the scanner's promise, not the brain's gate. A malformed version string must never 422 a scan - a rejected payload drops the repo's whole scan, findings and contributions included, and returns before the ingest run is even logged - so the brain accepts any bounded string and NORMALIZES an unparseable one to the unknown state at read time. Pinning a pattern here would make the canonical contract STRICTER than the implementation, which is the same class of drift as 1.22's looser-than-implementation gap, pointed the other way.",
+  "type": "object",
+  "required": [
+    "codebase",
+    "metrics"
+  ],
+  "properties": {
+    "codebase": {
+      "type": "object",
+      "required": [
+        "slug"
+      ],
+      "properties": {
+        "slug": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        },
+        "full_name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 250
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        }
+      },
+      "additionalProperties": true
+    },
+    "metrics": {
+      "type": "object",
+      "required": [
+        "head_sha",
+        "loc",
+        "files",
+        "commits_window",
+        "ai_commits_window",
+        "additions_window",
+        "deletions_window",
+        "recent_commits",
+        "has_claude_md",
+        "has_agents_md",
+        "agents_md_count",
+        "skills_count",
+        "commands_count"
+      ],
+      "properties": {
+        "head_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,40}$"
+        },
+        "window_days": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "loc": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "files": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "commits_window": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "ai_commits_window": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "additions_window": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "deletions_window": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "recent_commits": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "sha"
+            ],
+            "properties": {
+              "sha": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{7,40}$"
+              },
+              "author": {
+                "type": "string",
+                "maxLength": 120
+              },
+              "ai": {
+                "type": "boolean"
+              },
+              "committed_at": {
+                "type": "string",
+                "maxLength": 40
+              },
+              "commit_classification": {
+                "$ref": "#/$defs/commitClassification"
+              },
+              "fix_analysis": {
+                "$ref": "#/$defs/fixAnalysis"
+              }
+            },
+            "additionalProperties": true,
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "fix_analysis": {}
+                  },
+                  "required": [
+                    "fix_analysis"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "commit_classification"
+                  ],
+                  "properties": {
+                    "commit_classification": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "const": "fix"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "has_claude_md": {
+          "type": "boolean"
+        },
+        "has_agents_md": {
+          "type": "boolean"
+        },
+        "agents_md_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skills_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "commands_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "test_coverage_pct": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100
+        },
+        "test_coverage_lines_total": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "1.22. Instrumented lines the coverage report measured - the DENOMINATOR test_coverage_pct was computed over. null = UNKNOWN, never zero and never 'the whole repo'."
+        },
+        "test_coverage_lines_covered": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "1.22. Of test_coverage_lines_total, how many were hit. null = UNKNOWN."
+        },
+        "tests_total": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "1.22. Run integrity: the number of test cases the run collected. null = no test-result report, which is UNKNOWN and must not be read as zero."
+        },
+        "tests_passed": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "1.22. Run integrity: how many passed. null = no test-result report, which is UNKNOWN and must not be read as zero."
+        },
+        "tests_skipped": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "1.22. Run integrity: how many were skipped - non-zero marks the run partial. null = no test-result report, which is UNKNOWN and must not be read as zero."
+        },
+        "tests_failed": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "1.22. Run integrity: how many failed (JUnit failures + errors). null = no test-result report, which is UNKNOWN and must not be read as zero."
+        },
+        "readiness_level": {
+          "type": "string",
+          "pattern": "^L[1-5]$"
+        },
+        "readiness_pct": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "readiness_pillars": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "passed",
+              "total"
+            ],
+            "properties": {
+              "passed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "readiness_rubric_version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        },
+        "codebase_health": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/codebaseHealth"
+            },
+            {
+              "$ref": "#/$defs/codebaseHealthV2"
+            },
+            {
+              "$ref": "#/$defs/codebaseHealthV3"
+            }
+          ]
+        },
+        "scanner_version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 64,
+          "description": "brain-api 1.24 (AIO-1011). The version of the ingestion package that BUILT this payload - `aios_ingest.__version__`, a dotted semver such as \"0.2.0\". null or absent = UNKNOWN scanner build, which is what every scan produced before 1.24 reports; it is never read as \"current\". The brain compares it against the contract's declared `minScannerVersion` (see brain-contract.json's codebasePayloadContract block) to decide whether a repo's scanner predates what the current contract needs, and says so at the point of confusion instead of rendering an unexplained \"(scope unknown)\". A value the brain cannot parse as a version is treated as unknown, not rejected."
+        },
+        "scanner_sha": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 64,
+          "description": "brain-api 1.24 (AIO-1011). PROVENANCE ONLY: the git commit of the aios-team-brain checkout the scanner ran from, when it is knowable - `.github/scripts/fetch-brain-scanner.sh` leaves a real detached checkout at the pinned BRAIN_SHA, so the scanner can read its own build. null when the scanner was installed without git history (a future package install). Never used to compute staleness: commit identity is not ordered, is meaningless across branches, and stops existing the moment the scanner ships as a package. It exists so a stale repo's pin can be located and bumped without guessing."
+        }
+      },
+      "additionalProperties": true
+    },
+    "contributions": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "commitClassification": {
+      "title": "Commit classification (document revision 1.23, optional)",
+      "description": "Versioned Conventional Commit classification. `unparseable` is a measured class and remains in the all-observed denominator; it is not silently dropped.",
+      "type": "object",
+      "required": [
+        "scheme",
+        "type"
+      ],
+      "properties": {
+        "scheme": {
+          "const": "conventional-commit-v1"
+        },
+        "type": {
+          "enum": [
+            "fix",
+            "feat",
+            "other",
+            "unparseable"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "fixAnalysis": {
+      "title": "Fix analysis (document revision 1.23, optional)",
+      "description": "First-parent line-blame counts for a fix commit. Normative brain-enforced invariants: the age-bucket sum equals blamed_parent_lines; blamed_parent_lines is no greater than candidate_parent_lines; prior_fix_parent_lines is no greater than blamed_parent_lines. Counts only: no paths, patch text, line content, or source-sensitive material.",
+      "type": "object",
+      "required": [
+        "method",
+        "candidate_parent_lines",
+        "blamed_parent_lines",
+        "age_buckets",
+        "prior_fix_parent_lines"
+      ],
+      "properties": {
+        "method": {
+          "const": "first-parent-line-blame-v1"
+        },
+        "candidate_parent_lines": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "blamed_parent_lines": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "age_buckets": {
+          "type": "object",
+          "required": [
+            "0_1d",
+            "2_7d",
+            "8_30d",
+            "31_90d",
+            "91_365d",
+            "366d_plus"
+          ],
+          "properties": {
+            "0_1d": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "2_7d": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "8_30d": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "31_90d": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "91_365d": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "366d_plus": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "prior_fix_parent_lines": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "codebaseHealth": {
+      "title": "codebase_health (document revision 1.15, optional, provenance-only)",
+      "description": "Scalar-only workspace-governance health snapshot, scored scanner-side; the brain persists it verbatim and never recomputes it. All fields are required when the object is present. No file paths, no source text, no contributor identity — failed_invariant_ids are short rubric ids, never paths or findings text.",
+      "type": "object",
+      "required": [
+        "schema_version",
+        "rubric_version",
+        "head_sha",
+        "score_pct",
+        "status",
+        "dimensions",
+        "failed_invariant_ids",
+        "measured_at"
+      ],
+      "properties": {
+        "schema_version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20
+        },
+        "rubric_version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        },
+        "head_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,40}$"
+        },
+        "score_pct": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "status": {
+          "enum": [
+            "pass",
+            "warn",
+            "fail"
+          ]
+        },
+        "dimensions": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": {
+            "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "passed",
+              "total"
+            ],
+            "properties": {
+              "passed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "failed_invariant_ids": {
+          "type": "array",
+          "maxItems": 200,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+          }
+        },
+        "measured_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "codebaseHealthV2": {
+      "title": "AIOS codebase health v2",
+      "description": "Redacted codebase-health snapshot with explicit evidence completeness, per-repository capability profile, automation admission verdict, and normalized finding ledger.",
+      "type": "object",
+      "required": [
+        "schema_version",
+        "rubric_version",
+        "profile_id",
+        "profile_version",
+        "head_sha",
+        "score_pct",
+        "status",
+        "evidence_status",
+        "quality_gate",
+        "automation_eligible",
+        "dimensions",
+        "failed_invariant_ids",
+        "measured_at",
+        "findings"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "2"
+        },
+        "rubric_version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        },
+        "profile_id": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$"
+        },
+        "profile_version": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$"
+        },
+        "head_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,40}$"
+        },
+        "score_pct": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "status": {
+          "enum": [
+            "pass",
+            "warn",
+            "fail"
+          ]
+        },
+        "evidence_status": {
+          "$ref": "#/$defs/codebaseHealthV2/$defs/evidenceStatus"
+        },
+        "quality_gate": {
+          "enum": [
+            "pass",
+            "fail",
+            "unknown"
+          ]
+        },
+        "automation_eligible": {
+          "type": "boolean"
+        },
+        "dimensions": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": {
+            "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "passed",
+              "total",
+              "band",
+              "evidence_status"
+            ],
+            "properties": {
+              "passed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "band": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "minimum": 0,
+                "maximum": 4
+              },
+              "evidence_status": {
+                "$ref": "#/$defs/codebaseHealthV2/$defs/evidenceStatus"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "failed_invariant_ids": {
+          "type": "array",
+          "maxItems": 200,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+          }
+        },
+        "measured_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$"
+        },
+        "findings": {
+          "type": "array",
+          "maxItems": 500,
+          "items": {
+            "type": "object",
+            "required": [
+              "fingerprint",
+              "check_id",
+              "axis",
+              "kind",
+              "severity",
+              "evidence_status",
+              "remediation_tier"
+            ],
+            "properties": {
+              "fingerprint": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              },
+              "check_id": {
+                "type": "string",
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+              },
+              "axis": {
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$"
+              },
+              "kind": {
+                "enum": [
+                  "quality_issue",
+                  "evidence_gap"
+                ]
+              },
+              "severity": {
+                "enum": [
+                  "low",
+                  "medium",
+                  "high",
+                  "critical"
+                ]
+              },
+              "evidence_status": {
+                "$ref": "#/$defs/codebaseHealthV2/$defs/evidenceStatus"
+              },
+              "remediation_tier": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 3
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "quality_gate": {
+                "const": "pass"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence_status": {
+                "const": "complete"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "quality_gate": {
+                "const": "unknown"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence_status": {
+                "not": {
+                  "const": "complete"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "automation_eligible": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "quality_gate": {
+                "const": "pass"
+              },
+              "evidence_status": {
+                "const": "complete"
+              },
+              "status": {
+                "enum": [
+                  "pass",
+                  "warn"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "$defs": {
+        "evidenceStatus": {
+          "enum": [
+            "complete",
+            "partial",
+            "missing",
+            "stale",
+            "error"
+          ]
+        }
+      }
+    },
+    "codebaseHealthV3": {
+      "title": "AIOS codebase health v3",
+      "description": "Redacted codebase-health snapshot with explicit evidence completeness, per-repository capability profile, automation admission verdict, and normalized finding ledger.",
+      "type": "object",
+      "required": [
+        "schema_version",
+        "rubric_version",
+        "profile_id",
+        "profile_version",
+        "head_sha",
+        "score_pct",
+        "status",
+        "evidence_status",
+        "quality_gate",
+        "automation_eligible",
+        "dimensions",
+        "failed_invariant_ids",
+        "measured_at",
+        "findings",
+        "check_coverage"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "3"
+        },
+        "rubric_version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        },
+        "profile_id": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$"
+        },
+        "profile_version": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$"
+        },
+        "head_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,40}$"
+        },
+        "score_pct": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "status": {
+          "enum": [
+            "pass",
+            "warn",
+            "fail"
+          ]
+        },
+        "evidence_status": {
+          "$ref": "#/$defs/codebaseHealthV3/$defs/evidenceStatus"
+        },
+        "quality_gate": {
+          "enum": [
+            "pass",
+            "fail",
+            "unknown"
+          ]
+        },
+        "automation_eligible": {
+          "type": "boolean"
+        },
+        "dimensions": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": {
+            "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "passed",
+              "total",
+              "band",
+              "evidence_status"
+            ],
+            "properties": {
+              "passed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "band": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "minimum": 0,
+                "maximum": 4
+              },
+              "evidence_status": {
+                "$ref": "#/$defs/codebaseHealthV3/$defs/evidenceStatus"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "failed_invariant_ids": {
+          "type": "array",
+          "maxItems": 200,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+          }
+        },
+        "measured_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$"
+        },
+        "findings": {
+          "type": "array",
+          "maxItems": 500,
+          "items": {
+            "type": "object",
+            "required": [
+              "fingerprint",
+              "check_id",
+              "axis",
+              "kind",
+              "severity",
+              "evidence_status",
+              "remediation_tier"
+            ],
+            "properties": {
+              "fingerprint": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              },
+              "check_id": {
+                "type": "string",
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+              },
+              "axis": {
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$"
+              },
+              "kind": {
+                "enum": [
+                  "quality_issue",
+                  "evidence_gap"
+                ]
+              },
+              "severity": {
+                "enum": [
+                  "low",
+                  "medium",
+                  "high",
+                  "critical"
+                ]
+              },
+              "evidence_status": {
+                "$ref": "#/$defs/codebaseHealthV3/$defs/evidenceStatus"
+              },
+              "remediation_tier": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 3
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "check_coverage": {
+          "type": "object",
+          "required": [
+            "all",
+            "required"
+          ],
+          "properties": {
+            "all": {
+              "type": "object",
+              "required": [
+                "configured",
+                "complete",
+                "partial",
+                "missing",
+                "stale",
+                "error"
+              ],
+              "properties": {
+                "configured": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "complete": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "partial": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "missing": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "stale": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "error": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "additionalProperties": false
+            },
+            "required": {
+              "type": "object",
+              "required": [
+                "configured",
+                "complete",
+                "partial",
+                "missing",
+                "stale",
+                "error"
+              ],
+              "properties": {
+                "configured": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "complete": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "partial": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "missing": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "stale": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "error": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "quality_gate": {
+                "const": "pass"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence_status": {
+                "const": "complete"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "quality_gate": {
+                "const": "unknown"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence_status": {
+                "not": {
+                  "const": "complete"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "automation_eligible": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "quality_gate": {
+                "const": "pass"
+              },
+              "evidence_status": {
+                "const": "complete"
+              },
+              "status": {
+                "enum": [
+                  "pass",
+                  "warn"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "$defs": {
+        "evidenceStatus": {
+          "enum": [
+            "complete",
+            "partial",
+            "missing",
+            "stale",
+            "error"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/guards/codebase-payload-contract.test.ts
+++ b/test/guards/codebase-payload-contract.test.ts
@@ -291,3 +291,26 @@ describe("health v3 semantic census invariants", () => {
     }
   });
 });
+
+it("v3 inherits evidence/head constraints and cannot fall through the legacy schema", () => {
+  const entry = fixtures.valid.find((f) => f.name === "valid-v3-complete")!;
+  const payload = structuredClone(entry.payload) as {
+    metrics: { head_sha: string; codebase_health: Record<string, unknown> };
+  };
+  payload.metrics.head_sha = payload.metrics.codebase_health.head_sha as string;
+  expect(codebaseScanPayloadSchema.safeParse(payload).success).toBe(true);
+  for (const patch of [
+    { quality_gate: "pass", evidence_status: "partial" },
+    { quality_gate: "unknown", evidence_status: "complete" },
+    { automation_eligible: true, status: "fail" },
+    { head_sha: "f".repeat(40) },
+    { source: "/private/source.ts" },
+  ]) {
+    const invalid = structuredClone(payload);
+    Object.assign(invalid.metrics.codebase_health, patch);
+    expect(codebaseScanPayloadSchema.safeParse(invalid).success).toBe(false);
+  }
+  const missing = structuredClone(payload);
+  delete missing.metrics.codebase_health.check_coverage;
+  expect(codebaseScanPayloadSchema.safeParse(missing).success).toBe(false);
+});

--- a/test/guards/codebase-payload-contract.test.ts
+++ b/test/guards/codebase-payload-contract.test.ts
@@ -6,7 +6,7 @@ import { scannerStaleness } from "@/lib/codebases/scanner-version";
 import { codebaseScanPayloadSchema } from "@/lib/api/schemas";
 
 /**
- * Server-side conformance guard for the Brain API 1.24 codebase-scan payload
+ * Server-side conformance guard for the Brain API 1.25 codebase-scan payload
  * (POST /api/v1/codebases, incl. the optional provenance-only `metrics.codebase_health`
  * object — AIO-609). Mirror of aios-workspace/test/codebase-payload-contract.test.mjs,
  * run against vendored copies of the shared contract artifacts
@@ -32,7 +32,7 @@ const PINNED = {
   "codebase-payload-1.25.schema.json":
     "79cd93c4b46b7ded3af73ac0e320498036bc1e39d7677cad18a6554b1d620d66",
   "codebase-payload-1.25-fixtures.json":
-    "22bc99241032d38578be67a3130af08404efe4588cf678046fb687a00ab91d5a",
+    "d053f4aa12e9afb5d4b8c7a636f399b177ba51f1871f9c2472cab713b4f76b7e",
   "codebase-health-v2.schema.json":
     "38de45de129c9ff3a346fb96346f905d79532b053e824a4ac85bb26a88b4371d",
 } as const;

--- a/test/guards/codebase-payload-contract.test.ts
+++ b/test/guards/codebase-payload-contract.test.ts
@@ -29,17 +29,17 @@ import { codebaseScanPayloadSchema } from "@/lib/api/schemas";
 const CONTRACT_DIR = join(import.meta.dirname, "..", "fixtures", "contract");
 
 const PINNED = {
-  "codebase-payload-1.24.schema.json":
-    "761f8e74be2f98d2883d9d61697f7d0c95c28df7770ba7e467d35dd6492feca6",
-  "codebase-payload-1.24-fixtures.json":
-    "67fa64a19273c0ec78f571a9f956de19fb5174febdb1ba081c4e651fa024b7fd",
+  "codebase-payload-1.25.schema.json":
+    "79cd93c4b46b7ded3af73ac0e320498036bc1e39d7677cad18a6554b1d620d66",
+  "codebase-payload-1.25-fixtures.json":
+    "22bc99241032d38578be67a3130af08404efe4588cf678046fb687a00ab91d5a",
   "codebase-health-v2.schema.json":
     "38de45de129c9ff3a346fb96346f905d79532b053e824a4ac85bb26a88b4371d",
 } as const;
 
 const fixtures = JSON.parse(
   readFileSync(
-    join(CONTRACT_DIR, "codebase-payload-1.24-fixtures.json"),
+    join(CONTRACT_DIR, "codebase-payload-1.25-fixtures.json"),
     "utf8",
   ),
 ) as {
@@ -49,6 +49,10 @@ const fixtures = JSON.parse(
     readonly payload: unknown;
   }[];
   readonly invalid: readonly {
+    readonly name: string;
+    readonly payload: unknown;
+  }[];
+  readonly coverage_invalid: readonly {
     readonly name: string;
     readonly payload: unknown;
   }[];
@@ -71,7 +75,7 @@ const fixtures = JSON.parse(
   };
 };
 
-describe("brain-api 1.24 codebase-payload conformance", () => {
+describe("brain-api 1.25 codebase-payload conformance", () => {
   it("vendored contract artifacts are byte-identical to the pinned canonical revision", () => {
     for (const [file, sha] of Object.entries(PINNED)) {
       const bytes = readFileSync(join(CONTRACT_DIR, file));
@@ -100,15 +104,12 @@ describe("brain-api 1.24 codebase-payload conformance", () => {
       );
     });
 
-    it.each(vectors.map((v) => [v.name, v] as const))(
-      "%s",
-      (_name, v) => {
-        // An ABSENT key and an explicit null are different inputs that must reach the same
-        // verdict, so the absent case is passed as `undefined` rather than coerced to null.
-        const declared = "scanner_version" in v ? v.scanner_version : undefined;
-        expect(scannerStaleness(declared)).toBe(v.state);
-      },
-    );
+    it.each(vectors.map((v) => [v.name, v] as const))("%s", (_name, v) => {
+      // An ABSENT key and an explicit null are different inputs that must reach the same
+      // verdict, so the absent case is passed as `undefined` rather than coerced to null.
+      const declared = "scanner_version" in v ? v.scanner_version : undefined;
+      expect(scannerStaleness(declared)).toBe(v.state);
+    });
 
     it("UNPARSEABLE resolves to unknown and is NEVER ordered against the minimum", () => {
       // The load-bearing rule, asserted directly rather than inferred from the loop above:
@@ -147,7 +148,7 @@ describe("brain-api 1.24 codebase-payload conformance", () => {
       };
     };
     const block = brainContract.codebasePayloadContract;
-    expect(block.version).toBe("1.24");
+    expect(block.version).toBe("1.25");
     for (const ref of [block.schema, block.fixtures]) {
       const bytes = readFileSync(join(CONTRACT_DIR, ref.path));
       expect(createHash("sha256").update(bytes).digest("hex"), ref.path).toBe(
@@ -156,8 +157,8 @@ describe("brain-api 1.24 codebase-payload conformance", () => {
     }
   });
 
-  it("fixtures file tracks the 1.24 contract revision, both buckets populated", () => {
-    expect(fixtures.version).toBe("1.24");
+  it("fixtures file tracks the 1.25 contract revision, both buckets populated", () => {
+    expect(fixtures.version).toBe("1.25");
     expect(fixtures.valid.length).toBeGreaterThanOrEqual(3);
     expect(fixtures.invalid.length).toBeGreaterThanOrEqual(3);
   });
@@ -268,5 +269,25 @@ describe("brain-api 1.24 codebase-payload conformance", () => {
       malformed.metrics.codebase_health!.findings as Record<string, unknown>[]
     )[0].fingerprint;
     expect(codebaseScanPayloadSchema.safeParse(malformed).success).toBe(false);
+  });
+});
+
+describe("health v3 semantic census invariants", () => {
+  it.each(fixtures.coverage_invalid.map((f) => [f.name, f.payload] as const))(
+    "rejects %s",
+    (_name, payload) => {
+      expect(codebaseScanPayloadSchema.safeParse(payload).success).toBe(false);
+    },
+  );
+  it("preserves every v3 fixture as a whole object", () => {
+    for (const f of fixtures.valid.filter((f) =>
+      f.name.startsWith("valid-v3"),
+    )) {
+      const parsed = codebaseScanPayloadSchema.parse(f.payload);
+      expect(parsed.metrics.codebase_health).toEqual(
+        (f.payload as { metrics: { codebase_health: unknown } }).metrics
+          .codebase_health,
+      );
+    }
   });
 });

--- a/test/guards/codebase-payload-contract.test.ts
+++ b/test/guards/codebase-payload-contract.test.ts
@@ -314,6 +314,13 @@ it("v3 inherits evidence/head constraints and cannot fall through the legacy sch
     Object.assign(invalid.metrics.codebase_health, patch);
     expect(codebaseScanPayloadSchema.safeParse(invalid).success).toBe(false);
   }
+  const legacy = structuredClone(
+    fixtures.valid.find((f) => f.name.startsWith("valid-with-health:"))!
+      .payload,
+  ) as typeof payload;
+  legacy.metrics.codebase_health.schema_version = "3";
+  legacy.metrics.head_sha = legacy.metrics.codebase_health.head_sha as string;
+  expect(codebaseScanPayloadSchema.safeParse(legacy).success).toBe(false);
   const missing = structuredClone(payload);
   delete missing.metrics.codebase_health.check_coverage;
   expect(codebaseScanPayloadSchema.safeParse(missing).success).toBe(false);

--- a/test/guards/codebase-payload-contract.test.ts
+++ b/test/guards/codebase-payload-contract.test.ts
@@ -276,7 +276,11 @@ describe("health v3 semantic census invariants", () => {
   it.each(fixtures.coverage_invalid.map((f) => [f.name, f.payload] as const))(
     "rejects %s",
     (_name, payload) => {
-      expect(codebaseScanPayloadSchema.safeParse(payload).success).toBe(false);
+      const scenario = structuredClone(payload) as {
+        metrics: { head_sha: string; codebase_health: { head_sha: string } };
+      };
+      scenario.metrics.head_sha = scenario.metrics.codebase_health.head_sha;
+      expect(codebaseScanPayloadSchema.safeParse(scenario).success).toBe(false);
     },
   );
   it("preserves every v3 fixture as a whole object", () => {

--- a/test/guards/debt-patrol-ui.test.ts
+++ b/test/guards/debt-patrol-ui.test.ts
@@ -1,9 +1,14 @@
+import { codebaseHealthSchema } from "@/lib/api/schemas";
+import { isCodebaseStale } from "@/lib/metrics/codebases";
 import { renderToStaticMarkup } from "react-dom/server";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { DebtPatrol } from "@/components/codebases/debt-patrol";
-import { DebtMovement } from "@/components/codebases/debt-dashboard";
+import {
+  DebtMovement,
+  ScannerCheckCoverage,
+} from "@/components/codebases/debt-dashboard";
 import { buildDebtPatrol } from "@/lib/codebases/debt-ranking";
 import { deriveCodebaseDebtKpis } from "@/lib/codebases/debt-kpis";
 import type { CodebaseFinding } from "@/lib/metrics/codebases";
@@ -162,5 +167,146 @@ describe("debt patrol accessibility guard", () => {
       expect(query).toContain('.eq("codebase_id", codebaseId)');
       expect(query).not.toContain(".limit(");
     }
+  });
+});
+
+// AIO-1096: census labels, unknowns and freshness are observable independently of color.
+describe("scanner check coverage", () => {
+  const fixtureSet = JSON.parse(
+    readFileSync(
+      join(
+        process.cwd(),
+        "test/fixtures/contract/codebase-payload-1.25-fixtures.json",
+      ),
+      "utf8",
+    ),
+  );
+  const makeHealth = (name = "valid-v3-complete") => {
+    const health = codebaseHealthSchema.parse(
+      fixtureSet.valid.find((f: { name: string }) => f.name === name).payload
+        .metrics.codebase_health,
+    );
+    if (health.schema_version !== "3" || !("check_coverage" in health))
+      throw new Error("v3 fixture required");
+    return health;
+  };
+  it("labels every count, full provenance and capture time", () => {
+    const health = makeHealth();
+    const html = renderToStaticMarkup(
+      ScannerCheckCoverage({ health, stale: false }),
+    );
+    for (const label of [
+      "Scanner check coverage",
+      "Complete scan",
+      "Configured checks",
+      "Complete required",
+      "Findings emitted",
+      "All checks",
+      "Required checks",
+      "Partial",
+      "Missing",
+      "Stale",
+      "Error",
+      "Profile",
+      "Rubric",
+      "Head",
+      "Measured time",
+    ])
+      expect(html).toContain(label);
+    for (const value of [
+      health.profile_id,
+      health.profile_version,
+      health.rubric_version,
+      health.head_sha,
+      health.measured_at,
+    ])
+      expect(html).toContain(value);
+    expect(html).toContain('<th scope="row"');
+    expect(html).toContain(`dateTime="${health.measured_at}"`);
+  });
+  it("shows partial, stale and error cues together without claiming completeness", () => {
+    const health = makeHealth("valid-v3-mixed");
+    health.evidence_status = "error";
+    const html = renderToStaticMarkup(
+      ScannerCheckCoverage({ health, stale: true }),
+    );
+    for (const flag of ["Partial scan", "Stale scan", "Error evidence"])
+      expect(html).toContain(flag);
+    expect(html).not.toContain("Complete scan");
+  });
+  it("required completeness never means all-check completeness and zero is measured", () => {
+    const health = makeHealth();
+    health.check_coverage.all.complete -= 1;
+    health.check_coverage.all.partial += 1;
+    expect(
+      renderToStaticMarkup(ScannerCheckCoverage({ health, stale: false })),
+    ).toContain("Partial scan");
+    const zero = renderToStaticMarkup(
+      ScannerCheckCoverage({
+        health: makeHealth("valid-v3-zero"),
+        stale: false,
+      }),
+    );
+    expect(zero).toContain("No configured checks");
+    expect(zero).not.toContain("100%");
+    expect(zero).not.toContain("Complete scan");
+  });
+  it("renders absent and v1/v2 census as unknown rather than zero", () => {
+    const legacy = fixtureSet.valid.filter((f: { name: string }) =>
+      [
+        "valid-v2-unchanged",
+        "valid-with-health: full metrics block plus codebase_health",
+      ].includes(f.name),
+    );
+    expect(legacy).toHaveLength(2);
+    for (const health of [
+      null,
+      ...legacy.map(
+        (f: { payload: { metrics: { codebase_health: unknown } } }) =>
+          codebaseHealthSchema.parse(f.payload.metrics.codebase_health),
+      ),
+    ]) {
+      const html = renderToStaticMarkup(
+        ScannerCheckCoverage({ health, stale: true }),
+      );
+      expect(html).toContain("Coverage unknown");
+      expect(html).toContain("Configured checks: Unknown");
+      expect(html).not.toContain("Complete scan");
+      expect(html).not.toContain("<table");
+    }
+  });
+  it("places coverage below the intake gap and above debt; page freshness uses health time", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/codebases/debt-dashboard.tsx"),
+      "utf8",
+    );
+    const movement = source.slice(
+      source.indexOf("export function DebtMovement"),
+    );
+    expect(movement.indexOf('label="UltraHarden intake"')).toBeLessThan(
+      movement.indexOf("<ScannerCheckCoverage"),
+    );
+    expect(movement.indexOf("<ScannerCheckCoverage")).toBeLessThan(
+      movement.indexOf('aria-labelledby="debt-movement-heading"'),
+    );
+    const page = readFileSync(
+      join(process.cwd(), "app/t/[team]/codebases/[slug]/page.tsx"),
+      "utf8",
+    );
+    expect(page).toMatch(
+      /healthStale=\{isCodebaseStale\(\s*cb\.breakdown\?\.codebase_health\?\.measured_at/,
+    );
+    expect(
+      isCodebaseStale(
+        "2026-08-01T00:00:00Z",
+        Date.parse("2026-09-01T00:00:00Z"),
+      ),
+    ).toBe(true);
+    expect(
+      isCodebaseStale(
+        "2026-09-01T00:00:00Z",
+        Date.parse("2026-09-01T00:00:00Z"),
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## What & Why

Accept and preserve scanner health v3's configured-check census through the existing ingest writer and finding ledger. The codebase detail page now shows all/required coverage, emitted findings, provenance and capture time, with independent stale/error/partial cues and explicit unknown legacy data. Closed validation rejects invalid sums, subsets and inherited identity violations before scan-domain writes.

## Work item

AIOS-Work: AIO-1096

## Validation

- 5,927 unit tests passed; 39 isolated real-Postgres tests passed, including whole-object persistence, invalid-input no-write boundaries, auth/team isolation, mixed-version lifecycle and concurrent same-head snapshots.
- Sum, subset, legacy fallback and ledger-wrapper mutations each reddened their intended tests; original sources restored.
- Typecheck passed; lint has zero errors and 21 existing warnings; docs inventories agree.
- Twelve local actual-component screenshots cover five states at desktop/mobile sizes and complete-state dark mode. Independent Astra visual review found no blockers; fonts loaded and no horizontal overflow.
- Exact frozen member API 1.25 schema/fixtures/contract artifacts are vendored; no schema migration or new writer.

Concurrent differing same-head ingestion retains the existing transaction boundary: a superseded ledger RPC can return an identity error (observed responses 201/500), while one coherent submitted snapshot remains stored. Canonical artifact acceptance passed: all three vendored 1.25 artifacts are byte-identical to merged Workspace commit b8559ebf40b876dc36ac00605244af670edb1920 (PR689). The frozen contract snapshot preserves the 1.25 server declaration; no source changes were required. Deployment verification and producer activation remain coordinated release gates.

## Review summary

Reviewed by GPT-6 Astra — verdict CLEAR, no actionable P0/P1/P2 findings at 2256d7aa9a95a5881d283481707585024a63cc0c; independent code and UI reviews retained in the program evidence directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scan ingest validation and finding-ledger reconciliation for a new health schema revision; incorrect validation could reject valid scans or admit bad census data, though guards and Postgres tests cover the boundary.
> 
> **Overview**
> Bumps the member API to **brain-api v1.25** and adds **health v3** with a `check_coverage` census (all/required checks by evidence state). The Zod ingest boundary now accepts v3 alongside v1/v2, enforces census sum/subset rules and shared v2 evidence/head constraints, and persists the object verbatim in JSONB; finding reconciliation treats v3 like v2.
> 
> On the codebase detail page, **Scanner check coverage** appears above scanner-admitted debt: configured vs required completeness, findings count, provenance, and separate stale/partial/error flags (legacy v1/v2/absent shows explicit “unknown,” not zero). Freshness for that block uses `codebase_health.measured_at` via `isCodebaseStale` against debt KPI `asOf`.
> 
> Contract artifacts, docs, and conformance/datamechanics tests are updated for 1.25; no DB migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2256d7aa9a95a5881d283481707585024a63cc0c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->