### PR TITLE
docs(AIO-1101): vendor implemented intake availability metadata

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1847,7 +1847,10 @@ explicit, and required completeness never implies all-check completeness. Produc
 emission remains disabled until the separate production acceptance gate.
 
 The member conformance snapshot is now the full Workspace member API 1.26 contract,
-vendored from merge `b8559ebf40b876dc36ac00605244af670edb1920`. Scanner payloads
+vendored from Workspace merge `ce28fa75e6cbe35d7d7e3c9d9620e82cecd31255` (document
+revision 1.28). Its availability metadata identifies implemented Brain commit
+`87be1293dd8338dde953020c757bad336f2da9b4`; deployment and activation still require
+verification in each target environment, with no production availability claim. Scanner payloads
 remain independently pinned to `codebase-payload-1.25`; gateway remains 1.10.
 The earlier frozen 1.25 compatibility snapshot was used only by the coverage-only
 consumer before intake implementation.

--- a/test/fixtures/contract/brain-contract.json
+++ b/test/fixtures/contract/brain-contract.json
@@ -112,13 +112,13 @@
       "sha256": "d053f4aa12e9afb5d4b8c7a636f399b177ba51f1871f9c2472cab713b4f76b7e"
     }
   },
-  "contentHash": "22e8b27c0409d56acd7aff72a2da165f3c3b2e9a068c54443a3fa56e93b3f7aa",
+  "contentHash": "640339f218c054dfd39e0e32faf60d50e2f4aac21d63ad1750be870178778a11",
   "debtIntakeEventsContract": {
     "version": "1.26",
     "requestVersion": "debt-intake-events.v1",
     "method": "POST",
     "route": "/api/v1/codebases/:slug/debt-intake-events",
-    "availability": "contract-only; future Team Brain implementation AIO-1101",
+    "availability": "implemented in Team Brain commit 87be1293dd8338dde953020c757bad336f2da9b4; deployment and activation require verification in each target environment; no production availability claim",
     "harnessCommit": "691762a469f5e816d35a6263467c9e2d8cc98e8e",
     "maxRecords": 256,
     "maxRawBodyBytes": 1048576,


### PR DESCRIPTION
## Summary

Refresh the pinned member API 1.26 conformance snapshot from merged Workspace PR693 (`ce28fa75e6cbe35d7d7e3c9d9620e82cecd31255`). Availability now identifies the implemented intake endpoint while retaining target-environment deployment and activation gates. The architecture note records this source and document revision 1.28.

Only availability and contentHash differ in the JSON. The snapshot is byte-identical to its merged source (SHA-256 `bf5e92bf1d1e5a88e07d8d4accb17c6a7aac883ce72b012805589b65d917a75a`). API 1.26, scanner 1.25, gateway 1.10, schemas, fixtures and runtime behavior are unchanged. This does not claim production activation.

## Verification

- Canonical AIO-1101 phase specification verified; full clean-base SPEC_READY 100.
- 56 focused conformance/scanner tests passed.
- Documentation drift checks passed; exact JSON semantic delta and source hash verified.

AIO-1101

## Review — Reviewed by independent Codex Astra — verdict CLEAR at 0d55d8cde9a610a56b0b1d7b978be4ff6e1e89cb; no findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and conformance fixture metadata only; no API, schema, or runtime behavior changes.
> 
> **Overview**
> Updates the vendored **member API 1.26** conformance snapshot so **debt intake** availability reflects implementation instead of a contract-only placeholder.
> 
> In `brain-contract.json`, `debtIntakeEventsContract.availability` now points at Team Brain commit `87be1293…` and explicitly keeps **per-environment deployment/activation verification** with **no production availability claim**. The top-level `contentHash` is refreshed to match the new fixture bytes.
> 
> `ARCHITECTURE.md` is aligned with the new Workspace merge source (`ce28fa75…`, document revision **1.28**) and the same implementation commit note. API 1.26, scanner **1.25**, gateway **1.10**, and schemas/fixtures in the snapshot are unchanged aside from this metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d55d8cde9a610a56b0b1d7b978be4ff6e1e89cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->